### PR TITLE
Feat:post 게시글 생성,날짜,조회수 보이게 추가 + 사용자의 게시글 조회 추가

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
@@ -12,6 +12,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/post")
 public class PostController {
@@ -27,6 +29,11 @@ public class PostController {
     @GetMapping("/all")
     public ResponseEntity<Page<PostDto>> searchAll(@PageableDefault(size = 10, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
         return ResponseEntity.ok(postService.searchAllPost(pageable));
+    }
+
+    @GetMapping("/list/user/{id}")
+    public ResponseEntity<List<PostDto>> searchPostListByUser(@PathVariable Long id) {
+        return ResponseEntity.ok(postService.searchPostListByUser(id));
     }
 
     @PostMapping

--- a/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
@@ -43,4 +43,9 @@ public class PostController {
     public void deletePost(@PathVariable Long id) {
         postService.deletePost(id);
     }
+
+    @PutMapping("/view/{id}")
+    public void updateViewCount(@PathVariable Long id) {
+        postService.updateViewCount(id);
+    }
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
@@ -2,9 +2,11 @@ package com.dtalks.dtalks.board.post.dto;
 
 import com.dtalks.dtalks.board.comment.dto.CommentInfoDto;
 import com.dtalks.dtalks.board.post.entity.Post;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +29,12 @@ public class PostDto {
 
     private List<CommentInfoDto> commentList = new ArrayList<>();
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDate;
+
     @Builder
     public static PostDto toDto(Post post) {
         return PostDto.builder()
@@ -35,6 +43,8 @@ public class PostDto {
                 .content(post.getContent())
                 .nickname(post.getUser().getNickname())
                 .commentList(new ArrayList<>())
+                .createDate(post.getCreateDate())
+                .modifiedDate(post.getModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
@@ -29,6 +29,8 @@ public class PostDto {
 
     private List<CommentInfoDto> commentList = new ArrayList<>();
 
+    private Integer viewCount;
+
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createDate;
 
@@ -43,6 +45,7 @@ public class PostDto {
                 .content(post.getContent())
                 .nickname(post.getUser().getNickname())
                 .commentList(new ArrayList<>())
+                .viewCount(post.getViewCount())
                 .createDate(post.getCreateDate())
                 .modifiedDate(post.getModifiedDate())
                 .build();

--- a/src/main/java/com/dtalks/dtalks/board/post/entity/Post.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/entity/Post.java
@@ -34,12 +34,15 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Comment> commentList = new ArrayList<>();
 
+    private Integer viewCount;
+
     @Builder
     public static Post toEntity(PostRequestDto postDto, User user) {
         return Post.builder()
                 .title(postDto.getTitle())
                 .content(postDto.getContent())
                 .user(user)
+                .viewCount(0)
                 .build();
     }
 

--- a/src/main/java/com/dtalks/dtalks/board/post/repository/PostRepository.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/repository/PostRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByOrderByIdDesc(Pageable pageable);
+    List<Post> findByUserId(Long id);
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
@@ -5,9 +5,12 @@ import com.dtalks.dtalks.board.post.dto.PostRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PostService {
     PostDto searchById(Long id);
     Page<PostDto> searchAllPost(Pageable pageable);
+    List<PostDto> searchPostListByUser(Long userId);
 
     Long createPost(PostRequestDto postDto);
     Long updatePost(PostRequestDto postDto, Long id);

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
@@ -12,4 +12,6 @@ public interface PostService {
     Long createPost(PostRequestDto postDto);
     Long updatePost(PostRequestDto postDto, Long id);
     void deletePost(Long id);
+
+    void updateViewCount(Long id);
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -44,6 +44,18 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<PostDto> searchPostListByUser(Long userId) {
+        Optional<User> optionalUser = userRepository.findById(userId);
+        if (optionalUser.isEmpty()) {
+            throw new UserNotFoundException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다.");
+        }
+
+        List<Post> postList = postRepository.findByUserId(userId);
+        return postList.stream().map(PostDto::toDto).toList();
+    }
+
+    @Override
     @Transactional
     public Long createPost(PostRequestDto postDto) {
         Optional<User> user = Optional.ofNullable(userRepository.getByUserid(SecurityUtil.getCurrentUserId()));

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -89,4 +89,17 @@ public class PostServiceImpl implements PostService {
 
         postRepository.delete(post);
     }
+
+    @Override
+    @Transactional
+    public void updateViewCount(Long id) {
+        Optional<Post> optionalPost = postRepository.findById(id);
+        if (optionalPost.isEmpty()) {
+            throw new PostNotFoundException(ErrorCode.POST_NOT_FOUND_ERROR, "존재하지 않는 게시글입니다.");
+        }
+
+        Post post = optionalPost.get();
+        post.setViewCount(post.getViewCount() + 1);
+    }
+
 }


### PR DESCRIPTION
1. 게시글에서 생성 날짜, 수정 날짜 보이도록 dto 수정
2. 게시글에서 조회수가 보이도록 dto 수정, 조회수 업데이트 api 추가 (update하려는 post id 필요) http://localhost:8081 **/post/view/1**
3. 사용자의 게시글 리스트 조회 기능 추가 http://localhost:8081 **/post/list/user/1**  (조회하려는 사용자의 id (primary key) 필요, 추후 primary key가 아닌 nickname이나 다른 값으로 조회할거면 변경 가능)