### PR TITLE
fix: querydsl 배포 오류 수정 (스프링3.x버전), gitignore에 폴더 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+/src/main/generated
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -52,3 +52,11 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+def querydslDir = "src/main/generated/querydsl"
+clean {
+	delete file(querydslDir)
+}
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslDir)
+}


### PR DESCRIPTION
**받기 전에 Gradle -> Tasks -> build -> clean 실행으로 폴더 없애고 진행**

querydsl 스프링 3.x버전에 맞춰 수정
src/main/generated 폴더에 Q파일들이 생성됨으로 gitignore에 폴더명 추가