### PR TITLE
fix: post 빠진 @Transactional 추가, 조회수 업데이트 수정

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
@@ -28,7 +28,7 @@ public class PostController {
     private final FavoritePostService favoritePostService;
     private final RecommendPostService recommendPostService;
 
-    @Operation(summary = "특정 게시글 id로 조회")
+    @Operation(summary = "특정 게시글 id로 조회, 조회수 + 1 작동")
     @GetMapping("/{id}")
     public ResponseEntity<PostDto> searchById(@PathVariable Long id) {
         return ResponseEntity.ok(postService.searchById(id));
@@ -86,16 +86,6 @@ public class PostController {
     public void deletePost(@PathVariable Long id) {
         postService.deletePost(id);
     }
-
-
-    @Operation(summary = "게시글 조회수 업데이트 (+1)", parameters = {
-            @Parameter(name = "id", description = "조회한 게시글 id(db에 저장된 primary key)")
-    })
-    @PutMapping("/view/{id}")
-    public void updateViewCount(@PathVariable Long id) {
-        postService.updateViewCount(id);
-    }
-
 
     @Operation(summary = "게시글에 대한 사용자의 즐겨찾기, 추천 여부 확인, 로그인한 사용자일 경우에만 api 보내면 됨"
     , description = "게시글은 로그인 없이 조회가 가능하지만 로그인한 사용자의 경우에는 즐겨찾기, 추천 여부가 필요. 두 가지가 boolean 타입으로 나온다.")

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
@@ -19,5 +19,4 @@ public interface PostService {
     Long updatePost(PostRequestDto postDto, Long id);
     void deletePost(Long id);
 
-    void updateViewCount(Long id);
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -44,6 +44,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<PostDto> searchPostsByUser(Long userId, Pageable pageable) {
         Optional<User> optionalUser = userRepository.findById(userId);
         if (optionalUser.isEmpty()) {
@@ -55,12 +56,14 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<PostDto> searchByWord(String keyword, Pageable pageable) {
         Page<Post> posts = postRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(keyword, keyword, pageable);
         return posts.map(PostDto::toDto);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<PostDto> search5BestPosts() {
         List<Post> top5Posts = postRepository.findTop5ByOrderByRecommendCountDesc();
         return top5Posts.stream().map(PostDto::toDto).toList();

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -27,13 +27,15 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public PostDto searchById(Long id) {
-        Optional<Post> post = postRepository.findById(id);
-        if (post.isEmpty()) {
+        Optional<Post> optionalPost = postRepository.findById(id);
+        if (optionalPost.isEmpty()) {
             throw new PostNotFoundException(ErrorCode.POST_NOT_FOUND_ERROR, "존재하지 않는 게시글입니다.");
         }
-        return PostDto.toDto(post.get());
+        Post post = optionalPost.get();
+        post.setViewCount(post.getViewCount() + 1);
+        return PostDto.toDto(post);
     }
 
     @Override
@@ -114,18 +116,6 @@ public class PostServiceImpl implements PostService {
         }
 
         postRepository.delete(post);
-    }
-
-    @Override
-    @Transactional
-    public void updateViewCount(Long id) {
-        Optional<Post> optionalPost = postRepository.findById(id);
-        if (optionalPost.isEmpty()) {
-            throw new PostNotFoundException(ErrorCode.POST_NOT_FOUND_ERROR, "존재하지 않는 게시글입니다.");
-        }
-
-        Post post = optionalPost.get();
-        post.setViewCount(post.getViewCount() + 1);
     }
 
 }


### PR DESCRIPTION
- 사용자의 게시글 조회, 검색어로 게시글 검색, 베스트 5 게시글 조회에 빠진 @Transactional(readOnly = true) 추가

- 게시글 조회 api -> 조회수 업데이트 api로 작동되던걸 프론트분의 요청으로 게시글 조회 api에서 조회수 업데이트도 되도록 변경