### PR TITLE
fix:post 게시글 정렬 수정, securityConfig에서 사용하지 않는 패턴 삭제

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/post/repository/PostRepository.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/repository/PostRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    Page<Post> findAllByOrderByIdDesc(Pageable pageable);
     Page<Post> findByUserId(Long id, Pageable pageable);
     Page<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(String title, String content, Pageable pageable);
 

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -41,7 +41,7 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional(readOnly = true)
     public Page<PostDto> searchAllPost(Pageable pageable) {
-        Page<Post> postsPage = postRepository.findAllByOrderByIdDesc(pageable);
+        Page<Post> postsPage = postRepository.findAll(pageable);
         return postsPage.map(PostDto::toDto);
     }
 

--- a/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
@@ -38,7 +38,7 @@ public class SecurityConfiguration {
                 .and()
                 .authorizeHttpRequests()
                 .requestMatchers("/sign-in/**", "/sign-up", "exception", "/users/check/**", "/email/**"
-                        ,"/token/refresh", "/post/view/**").permitAll()
+                        ,"/token/refresh").permitAll()
                 .requestMatchers("**exception**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/post/**", "/comment/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/questions/**", "/answers/**").permitAll()


### PR DESCRIPTION
- 게시글 조회에서 db로 가져오는 명령어가 잘못 설정되어 있어 변경
- securityConfiguration의 인증이 필요 없는 패턴에서 삭제된 api인 /post/view/부분 삭제