### PR TITLE
fix:post 게시글 삭제시 즐겨찾기, 추천 테이블 검사

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/post/repository/FavoritePostRepository.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/repository/FavoritePostRepository.java
@@ -1,11 +1,16 @@
 package com.dtalks.dtalks.board.post.repository;
 
 import com.dtalks.dtalks.board.post.entity.FavoritePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FavoritePostRepository extends JpaRepository<FavoritePost, Long> {
     Optional<FavoritePost> findByPostIdAndUserId(Long postId, Long userId);
+    Page<FavoritePost> findByUserId(Long userId, Pageable pageable);
+    List<FavoritePost> findByPostId(Long postId);
     boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/repository/RecommendPostRepository.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/repository/RecommendPostRepository.java
@@ -3,9 +3,11 @@ package com.dtalks.dtalks.board.post.repository;
 import com.dtalks.dtalks.board.post.entity.RecommendPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RecommendPostRepository extends JpaRepository<RecommendPost, Long> {
     Optional<RecommendPost> findByPostIdAndUserId(Long postId, Long userId);
+    List<RecommendPost> findByPostId(Long postId);
     boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -1,6 +1,10 @@
 package com.dtalks.dtalks.board.post.service;
 
+import com.dtalks.dtalks.board.post.entity.FavoritePost;
 import com.dtalks.dtalks.board.post.entity.Post;
+import com.dtalks.dtalks.board.post.entity.RecommendPost;
+import com.dtalks.dtalks.board.post.repository.FavoritePostRepository;
+import com.dtalks.dtalks.board.post.repository.RecommendPostRepository;
 import com.dtalks.dtalks.exception.exception.PermissionNotGrantedException;
 import com.dtalks.dtalks.board.post.dto.PostDto;
 import com.dtalks.dtalks.board.post.dto.PostRequestDto;
@@ -25,6 +29,8 @@ public class PostServiceImpl implements PostService {
 
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final FavoritePostRepository favoritePostRepository;
+    private final RecommendPostRepository recommendPostRepository;
 
     @Override
     @Transactional
@@ -113,6 +119,16 @@ public class PostServiceImpl implements PostService {
         String userId = post.getUser().getUserid();
         if (!userId.equals(SecurityUtil.getCurrentUserId())) {
             throw new PermissionNotGrantedException(ErrorCode.PERMISSION_NOT_GRANTED_ERROR, "해당 게시글을 삭제할 수 있는 권한이 없습니다.");
+        }
+
+        List<FavoritePost> favoritePostList = favoritePostRepository.findByPostId(post.getId());
+        for (FavoritePost favoritePost : favoritePostList) {
+            favoritePostRepository.delete(favoritePost);
+        }
+
+        List<RecommendPost> recommendPostList = recommendPostRepository.findByPostId(post.getId());
+        for (RecommendPost recommendPost : recommendPostList) {
+            recommendPostRepository.delete(recommendPost);
         }
 
         postRepository.delete(post);


### PR DESCRIPTION
게시글 삭제시 두 테이블을 검사해서 있으면 삭제하고 게시글 삭제하는 로직 추가