### PR TITLE
Feat: 사용자 최근활동 비공개 설정 추가, 인증 없이 되도록 수정

### DIFF
--- a/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
@@ -40,6 +40,7 @@ public class SecurityConfiguration {
                 .requestMatchers("/sign-in/**", "/sign-up", "exception", "/users/check/**", "/email/**"
                         ,"/token/refresh").permitAll()
                 .requestMatchers("**exception**").permitAll()
+                .requestMatchers("/users/recent/activity/**", "/users/private/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/post/**", "/comment/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/questions/**", "/answers/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/users/profile/image").permitAll()

--- a/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
+++ b/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
@@ -9,6 +9,7 @@ import com.dtalks.dtalks.user.entity.User;
 import com.dtalks.dtalks.user.service.UserDetailsService;
 import com.dtalks.dtalks.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
@@ -88,10 +89,31 @@ public class UserController {
         return ResponseEntity.ok(userService.updateUserDescription(description));
     }
 
-    @GetMapping(value = "/recent/activity")
-    public ResponseEntity<Page<RecentActivityDto>> getRecentActivities(@PageableDefault(size = 10, sort = "createDate",  direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(userService.getRecentActivities(pageable));
+    @GetMapping(value = "/recent/activity/{nickname}")
+    @Operation(summary = "특정 유저의 최근활동 조회 (페이지 사용, size = 10, sort=\"createDate\" desc 적용)", parameters = {
+            @Parameter(name = "nickname", description = "조회할 유저의 닉네임")
+    })
+    public ResponseEntity<Page<RecentActivityDto>> getRecentActivities(@PathVariable String nickname,
+                                                                       @PageableDefault(size = 10, sort = "createDate",  direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(userService.getRecentActivities(nickname, pageable));
 
+    }
+
+    @Operation(summary = "특정 유저의 비공개 여부 조회", parameters = {
+            @Parameter(name = "id", description = "조회할 유저의 로그인 아이디"),
+    })
+    @GetMapping(value = "/private/{id}")
+    public ResponseEntity<Boolean> getPrivateStatus(@PathVariable String id) {
+        return ResponseEntity.ok(userService.getPrivateStatus(id));
+    }
+
+    @Operation(summary = "특정 유저의 비공개 여부 설정", parameters = {
+            @Parameter(name = "id", description = "조회할 유저의 로그인 아이디"),
+            @Parameter(name = "status", description = "비공개 설정 true/false")
+    })
+    @PutMapping(value = "/setting/private/{id}/{status}")
+    public void updatePrivate(@PathVariable String id, @PathVariable boolean status) {
+        userService.updatePrivate(id, status);
     }
 
     @Operation(summary = "유저 기술스택 수정")

--- a/src/main/java/com/dtalks/dtalks/user/dto/RecentActivityDto.java
+++ b/src/main/java/com/dtalks/dtalks/user/dto/RecentActivityDto.java
@@ -28,16 +28,16 @@ public class RecentActivityDto {
     private String writer;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime activityTime;
+    private LocalDateTime createDate;
 
     @Builder
-    public static RecentActivityDto toDto(Long id, ActivityType type, String title, String writer, LocalDateTime activityTime) {
+    public static RecentActivityDto toDto(Long id, ActivityType type, String title, String writer, LocalDateTime createDate) {
         return RecentActivityDto.builder()
                 .id(id)
                 .type(type)
                 .title(title)
                 .writer(writer)
-                .activityTime(activityTime)
+                .createDate(createDate)
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/user/entity/User.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/User.java
@@ -70,6 +70,9 @@ public class User extends BaseTimeEntity implements UserDetails{
 
     private String status;
 
+    @Column(nullable = false)
+    private Boolean isPrivate;
+
     @OneToOne
     private Document profileImage;
 
@@ -139,6 +142,7 @@ public class User extends BaseTimeEntity implements UserDetails{
                 .registrationId(userDto.getRegistrationId())
                 .roles(Collections.singletonList("USER"))
                 .isActive(userDto.isActive())
+                .isPrivate(false)
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/user/service/UserService.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserService.java
@@ -32,7 +32,9 @@ public interface UserService {
 
     UserResponseDto updateUserSkills(List<Skill> skills);
 
-    Page<RecentActivityDto> getRecentActivities(Pageable pageable);
+    Page<RecentActivityDto> getRecentActivities(String nickname, Pageable pageable);
+    void updatePrivate(String id, boolean status);
+    Boolean getPrivateStatus(String id);
 
     SignInResponseDto oAuthSignUp(OAuthSignUpDto oAuthSignUpDto);
 }


### PR DESCRIPTION
1. User에 isPrivate 추가로 사용자 비공개 설정 추가
2. 회원가입때 user.setIsPrivate(false) 추가
3. 사용자 최근활동 조회 닉네임으로 하도록 변경 + 로그인하지 않아도 볼 수 있도록 SecurityConfig 수정
4. 비공개 여부로 최근활동 조회 가능한지 알 수 있는 api 추가 (/users/private/{id}). 이거 조회 후에 false이면 최근활동 조회 날리면 됨. 비공개 여부 조회도 인증 없이 가능
5. 비공개 여부 설정할 수 있는 api 추가 (/users/setting/private/{id}/{status}): status가 true이면 비공개 설정되는 것