### PR TITLE
feat: news 기사 crawling 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	//Jsoup
+	implementation 'org.jsoup:jsoup:1.15.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dtalks/dtalks/news/controller/NewsController.java
+++ b/src/main/java/com/dtalks/dtalks/news/controller/NewsController.java
@@ -1,0 +1,24 @@
+package com.dtalks.dtalks.news.controller;
+
+import com.dtalks.dtalks.news.entity.News;
+import com.dtalks.dtalks.news.service.NewsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class NewsController {
+    private final NewsService newsService;
+
+    @Operation(summary = "News 클로링 해오는 api", description = "BLOTER 사이트의 IT 기업 new 기사(제목, 내용, 작성자, 날짜, 이미지 주소, 링크) 반환")
+    @GetMapping("/news")
+    public ResponseEntity<List<News>> getNews() {
+        List<News> newsList = newsService.getNews();
+        return ResponseEntity.ok(newsList);
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/news/entity/News.java
+++ b/src/main/java/com/dtalks/dtalks/news/entity/News.java
@@ -1,0 +1,21 @@
+package com.dtalks.dtalks.news.entity;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class News {
+    private String title;
+
+    private String content;
+
+    private String writer;
+
+    private String date;
+
+    private String image;
+
+    private String url;
+}

--- a/src/main/java/com/dtalks/dtalks/news/entity/NewsCrawler.java
+++ b/src/main/java/com/dtalks/dtalks/news/entity/NewsCrawler.java
@@ -1,0 +1,35 @@
+package com.dtalks.dtalks.news.entity;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class NewsCrawler {
+    public List<News> crawlNews() throws IOException {
+        List<News> newsList = new ArrayList<>();
+
+        String pageUrl = "https://www.bloter.net/news/articleList.html?sc_sub_section_code=S2N15&view_type=sm";//크롤링할 사이트
+        Document document = Jsoup.connect(pageUrl).get();
+        Elements elements = document.select("#section-list > ul > li");// 뉴스 요소 css
+
+        for (Element element : elements) {
+            String title = element.select("h2.titles").text();
+            String content = element.select("p.lead.line-6x2").text();
+            String writer = element.select("em:nth-child(2)").text();
+            String image = element.select("img").attr("src");
+            String date = element.select("em:nth-child(3)").text();
+            String url = "https://www.bloter.net/" + element.select("a.thumb").attr("href");
+
+            News news = new News(title, content, writer, date, image, url);
+            newsList.add(news);
+        }
+        return newsList;
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/news/service/NewsService.java
+++ b/src/main/java/com/dtalks/dtalks/news/service/NewsService.java
@@ -1,0 +1,9 @@
+package com.dtalks.dtalks.news.service;
+
+import com.dtalks.dtalks.news.entity.News;
+
+import java.util.List;
+
+public interface NewsService {
+    List<News> getNews();
+}

--- a/src/main/java/com/dtalks/dtalks/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/news/service/NewsServiceImpl.java
@@ -1,0 +1,28 @@
+package com.dtalks.dtalks.news.service;
+
+import com.dtalks.dtalks.exception.ErrorCode;
+import com.dtalks.dtalks.exception.exception.CustomException;
+import com.dtalks.dtalks.news.entity.News;
+import com.dtalks.dtalks.news.entity.NewsCrawler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsServiceImpl implements NewsService {
+    private final NewsCrawler newsCrawler;
+
+
+    @Override
+    public List<News> getNews() {
+        try {
+            List<News> newsList = newsCrawler.crawlNews();
+            return newsList;
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "뉴스가 존재하지 않습니다. ");
+        }
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
@@ -44,6 +44,7 @@ public class SecurityConfiguration {
                 .requestMatchers(HttpMethod.GET, "/post/**", "/comment/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/questions/**", "/answers/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/users/profile/image").permitAll()
+                .requestMatchers(HttpMethod.GET, "/news").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())


### PR DESCRIPTION
get: /news: bloter.net 사이트의 IT 기업 섹션의 기사들을 클롤링 해온다. (제목, 내용, 작성자, 날짜, 이미지 주소, 링크) 반환