### PR TITLE
Feature/activity, comment

### DIFF
--- a/src/main/java/com/dtalks/dtalks/base/config/ScheduleConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/base/config/ScheduleConfiguration.java
@@ -1,0 +1,9 @@
+package com.dtalks.dtalks.base.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class ScheduleConfiguration {
+}

--- a/src/main/java/com/dtalks/dtalks/base/service/Schedule.java
+++ b/src/main/java/com/dtalks/dtalks/base/service/Schedule.java
@@ -1,0 +1,26 @@
+package com.dtalks.dtalks.base.service;
+
+import com.dtalks.dtalks.user.repository.ActivityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class Schedule {
+
+    @Autowired
+    private final ActivityRepository activityRepository;
+
+    @Scheduled(cron = "0 0 0 1 * ?")
+    @Transactional
+    @Async
+    public void activityDeleteSchedule() {
+        activityRepository.deleteByCreateDateLessThan(LocalDateTime.now().minusMonths(1));
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/board/comment/controller/CommentController.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.dtalks.dtalks.board.comment.controller;
 
 import com.dtalks.dtalks.board.comment.dto.CommentInfoDto;
 import com.dtalks.dtalks.board.comment.dto.CommentRequestDto;
+import com.dtalks.dtalks.board.comment.dto.UserCommentDto;
 import com.dtalks.dtalks.board.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -37,8 +38,8 @@ public class CommentController {
             @Parameter(name = "userId", description = "조회할 유저의 id (userId, 로그인할때 사용하는 아이디)")
     })
     @GetMapping("/list/user/{userId}")
-    public ResponseEntity<List<CommentInfoDto>> searchUserIdCommentList(@PathVariable String userId) {
-        List<CommentInfoDto> list = commentService.searchListByUserId(userId);
+    public ResponseEntity<List<UserCommentDto>> searchUserIdCommentList(@PathVariable String userId) {
+        List<UserCommentDto> list = commentService.searchListByUserId(userId);
         return ResponseEntity.ok(list);
     }
 

--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/UserCommentDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/UserCommentDto.java
@@ -1,0 +1,43 @@
+package com.dtalks.dtalks.board.comment.dto;
+
+import com.dtalks.dtalks.board.comment.entity.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "사용자의 댓글 리스트 DTO")
+public class UserCommentDto {
+    @Schema(description = "댓글 db에 저장된 id, primary key")
+    private Long id;
+
+    @Schema(description = "댓글을 단 게시글의 id, 게시글 조회할 때 보내는 것")
+    private Long postId;
+
+    @Schema(description = "댓글을 단 게시글의 제목")
+    private String postTitle;
+
+    @NotBlank
+    String content;
+
+    @Schema(description = "비밀글 여부")
+    boolean isSecret;
+
+    @Builder
+    public static UserCommentDto toDto(Comment comment, Long postId, String title) {
+        return UserCommentDto.builder()
+                .id(comment.getId())
+                .postId(postId)
+                .postTitle(title)
+                .content(comment.getContent())
+                .isSecret(comment.isSecret())
+                .build();
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/board/comment/service/CommentService.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/service/CommentService.java
@@ -2,13 +2,14 @@ package com.dtalks.dtalks.board.comment.service;
 
 import com.dtalks.dtalks.board.comment.dto.CommentInfoDto;
 import com.dtalks.dtalks.board.comment.dto.CommentRequestDto;
+import com.dtalks.dtalks.board.comment.dto.UserCommentDto;
 
 import java.util.List;
 
 public interface CommentService {
     CommentInfoDto searchById(Long id);
     List<CommentInfoDto> searchListByPostId(Long postId);
-    List<CommentInfoDto> searchListByUserId(String userId);
+    List<UserCommentDto> searchListByUserId(String userId);
 
     void saveComment(Long postId, CommentRequestDto dto);
     void saveReComment(Long postId, Long parentId, CommentRequestDto dto);

--- a/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.dtalks.dtalks.board.comment.service;
 
 import com.dtalks.dtalks.board.comment.dto.CommentInfoDto;
+import com.dtalks.dtalks.board.comment.dto.UserCommentDto;
 import com.dtalks.dtalks.board.comment.entity.Comment;
 import com.dtalks.dtalks.board.comment.dto.CommentRequestDto;
 import com.dtalks.dtalks.board.comment.repository.CommentRepository;
@@ -75,7 +76,7 @@ public class CommentServiceImpl implements CommentService{
 
     @Override
     @Transactional(readOnly = true)
-    public List<CommentInfoDto> searchListByUserId(String userId) {
+    public List<UserCommentDto> searchListByUserId(String userId) {
         Optional<User> optionalUser = Optional.ofNullable(userRepository.getByUserid(userId));
         if (optionalUser.isEmpty()) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다.");
@@ -83,7 +84,10 @@ public class CommentServiceImpl implements CommentService{
 
         User user = optionalUser.get();
         List<Comment> commentList = commentRepository.findByUserIdAndIsRemovedFalse(user.getId());
-        return commentList.stream().map(CommentInfoDto::toDto).toList();
+        return commentList.stream().map(c -> {
+            Post post = c.getPost();
+            return UserCommentDto.toDto(c, post.getId(), post.getTitle());
+        }).toList();
     }
 
     @Override

--- a/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
@@ -213,7 +213,8 @@ public class CommentServiceImpl implements CommentService{
         if (optionalActivity.isEmpty()) {
             throw new CustomException(ErrorCode.ACTIVITY_NOT_FOUND_ERROR, "해당 댓글 활동을 찾을 수 없습니다.");
         }
-        activityRepository.delete(optionalActivity.get());
+        Activity activity = optionalActivity.get();
+        activity.setComment(null);
 
         /**
          * 삭제하려는 댓글의 자식 댓글이 있는 경우

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -144,12 +144,10 @@ public class PostServiceImpl implements PostService {
         // 게시글이면 삭제, 댓글이면 연관관계들만 끊고 기록에는 남아있도록. 프론트에서 활동 클릭시 없는 게시글이라고 뜨게 하면 됨
         List<Activity> postList = activityRepository.findByPostId(post.getId());
         for (Activity activity : postList) {
-            if (activity.getType().equals(ActivityType.POST)) {
-                activityRepository.delete(activity);
-            } else {
-                activity.setPost(null);
+            if (activity.getType().equals(ActivityType.COMMENT)) {
                 activity.setComment(null);
             }
+            activity.setPost(null);
         }
 
         postRepository.delete(post);

--- a/src/main/java/com/dtalks/dtalks/user/repository/ActivityRepository.java
+++ b/src/main/java/com/dtalks/dtalks/user/repository/ActivityRepository.java
@@ -22,4 +22,6 @@ public interface ActivityRepository extends JpaRepository<Activity, Long> {
     List<Activity> findByPostIdAndType(Long postId, ActivityType type);
 
     Page<Activity> findByUserIdAndCreateDateBetween(Long userId, LocalDateTime goe, LocalDateTime loe, Pageable pageable);
+
+    void deleteByCreateDateLessThan(LocalDateTime deleteDate);
 }


### PR DESCRIPTION
- 게시글, 댓글 삭제시 최근활동은 남아있도록 수정 (기존에는 삭제됐음)
- 사용자 댓글 리스트 조회시 게시글 제목 보이도록 수정
- 매달 1일마다 최근활동 기록 삭제 스케줄러 추가(예시: 7월1일 00:00에 6월1일 이전 기록 삭제)