### PR TITLE
fix: 스터디룸 추방 api, 페이지 추가, 스터디룸삭제 수정

### DIFF
--- a/src/main/java/com/dtalks/dtalks/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/controller/StudyRoomController.java
@@ -81,7 +81,7 @@ public class StudyRoomController {
     @Operation(summary = "스터디룸 가입 신청 리스트")
     @GetMapping("study-rooms/requests")
     public ResponseEntity<Page<StudyRoomJoinResponseDto>> requestStudyRoom(
-            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC, page = 0) @ParameterObject Pageable pageable
+            @PageableDefault(size = 10, page = 0) @ParameterObject Pageable pageable
     ) {
         return ResponseEntity.ok(studyRoomService.studyRoomRequestList(pageable));
     }
@@ -103,5 +103,13 @@ public class StudyRoomController {
     @DeleteMapping("study-room/expel/{studyRoomId}/{nickname}")
     public ResponseEntity<StudyRoomResponseDto> expelStudyRoomUser(Long studyRoomId, String nickname) {
         return ResponseEntity.ok(studyRoomService.expelStudyRoomUser(studyRoomId, nickname));
+    }
+
+    @Operation(summary = "가입중인 스터디룸 조회")
+    @GetMapping("study-rooms/user")
+    public ResponseEntity<Page<StudyRoomResponseDto>> joinedStudyRoom(
+            @PageableDefault(size = 10, page = 0) @ParameterObject Pageable pageable
+    ) {
+        return ResponseEntity.ok(studyRoomService.JoinedStudyRoomList(pageable));
     }
 }

--- a/src/main/java/com/dtalks/dtalks/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/controller/StudyRoomController.java
@@ -80,8 +80,10 @@ public class StudyRoomController {
 
     @Operation(summary = "스터디룸 가입 신청 리스트")
     @GetMapping("study-rooms/requests")
-    public ResponseEntity<List<StudyRoomJoinResponseDto>> requestStudyRoom() {
-        return ResponseEntity.ok(studyRoomService.studyRoomRequestList());
+    public ResponseEntity<Page<StudyRoomJoinResponseDto>> requestStudyRoom(
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC, page = 0) @ParameterObject Pageable pageable
+    ) {
+        return ResponseEntity.ok(studyRoomService.studyRoomRequestList(pageable));
     }
 
     @Operation(summary = "스터디룸 가입 승인")

--- a/src/main/java/com/dtalks/dtalks/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/controller/StudyRoomController.java
@@ -98,4 +98,10 @@ public class StudyRoomController {
         studyRoomService.deleteStudyRoomUser(studyRoomId);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "스터디룸원 추방")
+    @DeleteMapping("study-room/expel/{studyRoomId}/{nickname}")
+    public ResponseEntity<StudyRoomResponseDto> expelStudyRoomUser(Long studyRoomId, String nickname) {
+        return ResponseEntity.ok(studyRoomService.expelStudyRoomUser(studyRoomId, nickname));
+    }
 }

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomService.java
@@ -28,4 +28,6 @@ public interface StudyRoomService {
     public void deleteStudyRoomUser(Long id);
 
     public StudyRoomResponseDto expelStudyRoomUser(Long studyRoomId, String nickname);
+
+    public Page<StudyRoomResponseDto> JoinedStudyRoomList(Pageable pageable);
 }

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomService.java
@@ -26,4 +26,6 @@ public interface StudyRoomService {
     public StudyRoomResponseDto acceptJoinStudyRoom(Long studyRoomId, Long studyRoomUserId);
 
     public void deleteStudyRoomUser(Long id);
+
+    public StudyRoomResponseDto expelStudyRoomUser(Long studyRoomId, String nickname);
 }

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomService.java
@@ -21,7 +21,7 @@ public interface StudyRoomService {
 
     public void deleteStudyRoom(Long id);
 
-    public List<StudyRoomJoinResponseDto> studyRoomRequestList();
+    public Page<StudyRoomJoinResponseDto> studyRoomRequestList(Pageable pageable);
 
     public StudyRoomResponseDto acceptJoinStudyRoom(Long studyRoomId, Long studyRoomUserId);
 

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
@@ -279,6 +279,22 @@ public class StudyRoomServiceImpl implements StudyRoomService{
         return StudyRoomResponseDto.toDto(studyRoom);
     }
 
+    @Override
+    @Transactional
+    public Page<StudyRoomResponseDto> JoinedStudyRoomList(Pageable pageable) {
+        User user = userRepository.getByUserid(SecurityUtil.getCurrentUserId());
+        List<StudyRoomUser> studyRoomUsers = studyRoomUserRepository.findAllByUser(user);
+        List<StudyRoomResponseDto> studyRoomResponseDtos = new ArrayList<>();
+        for(StudyRoomUser studyRoomUser: studyRoomUsers) {
+            studyRoomResponseDtos.add(StudyRoomResponseDto.toDto(studyRoomUser.getStudyRoom()));
+        }
+
+        int start = (int)pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), studyRoomResponseDtos.size());
+
+        return new PageImpl<>(studyRoomResponseDtos.subList(start, end), pageable, studyRoomResponseDtos.size());
+    }
+
     public boolean isLeader(StudyRoomUser studyRoomUser) {
         if(studyRoomUser.getStudyRoomLevel().equals(StudyRoomLevel.LEADER))
             return true;

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
@@ -280,7 +280,7 @@ public class StudyRoomServiceImpl implements StudyRoomService{
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<StudyRoomResponseDto> JoinedStudyRoomList(Pageable pageable) {
         User user = userRepository.getByUserid(SecurityUtil.getCurrentUserId());
         List<StudyRoomUser> studyRoomUsers = studyRoomUserRepository.findAllByUser(user);


### PR DESCRIPTION
- 스터디룸 삭제시 본인 이외의 스터디룸 멤버가 남아있으면 삭제 불가능하게 변경
- 스터디룸 가입 요청 리스트 페이지로 변경
- 스터디룸원 추방 api
- 가입중인 스터디룸 조회 api