### PR TITLE
fix:Crawling해서 DB에 저장, Crawl 정보 DB에서 조회

### DIFF
--- a/src/main/java/com/dtalks/dtalks/news/controller/NewsController.java
+++ b/src/main/java/com/dtalks/dtalks/news/controller/NewsController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -19,6 +20,13 @@ public class NewsController {
     @GetMapping("/news")
     public ResponseEntity<List<News>> getNews() {
         List<News> newsList = newsService.getNews();
+        return ResponseEntity.ok(newsList);
+    }
+
+    @Operation(summary = "News 클로링해 DB에 저장하는 api", description = "BLOTER 사이트의 IT 기업 new 기사(제목, 내용, 작성자, 날짜, 이미지 주소, 링크) 저장")
+    @PostMapping("/news")
+    public ResponseEntity<List<News>> saveNews() {
+        List<News> newsList = newsService.saveNews();
         return ResponseEntity.ok(newsList);
     }
 }

--- a/src/main/java/com/dtalks/dtalks/news/controller/NewsController.java
+++ b/src/main/java/com/dtalks/dtalks/news/controller/NewsController.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class NewsController {
     private final NewsService newsService;
 
-    @Operation(summary = "News 클로링 해오는 api", description = "BLOTER 사이트의 IT 기업 new 기사(제목, 내용, 작성자, 날짜, 이미지 주소, 링크) 반환")
+    @Operation(summary = "최신 20개 뉴스 불러오는 api", description = "BLOTER 사이트의 IT 기업 new 기사(제목, 내용, 작성자, 날짜, 이미지 주소, 링크) 반환")
     @GetMapping("/news")
     public ResponseEntity<List<News>> getNews() {
         List<News> newsList = newsService.getNews();

--- a/src/main/java/com/dtalks/dtalks/news/entity/News.java
+++ b/src/main/java/com/dtalks/dtalks/news/entity/News.java
@@ -1,21 +1,40 @@
 package com.dtalks.dtalks.news.entity;
 
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Entity
 public class News {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     private String title;
 
     private String content;
 
     private String writer;
 
-    private String date;
-
     private String image;
 
+    private String date;
+
+    @Column(unique = true)
     private String url;
+
+
+    @Builder
+    public static News toEntity(String title, String content, String writer, String image, String date, String url) {
+        return News.builder()
+                .title(title)
+                .content(content)
+                .writer(writer)
+                .image(image)
+                .date(date)
+                .url(url)
+                .build();
+    }
 }

--- a/src/main/java/com/dtalks/dtalks/news/repository/NewsRepository.java
+++ b/src/main/java/com/dtalks/dtalks/news/repository/NewsRepository.java
@@ -3,6 +3,10 @@ package com.dtalks.dtalks.news.repository;
 import com.dtalks.dtalks.news.entity.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NewsRepository extends JpaRepository<News, Long> {
     News findByUrl(String url);
+    List<News> findTop20ByOrderByDateDesc();
+
 }

--- a/src/main/java/com/dtalks/dtalks/news/repository/NewsRepository.java
+++ b/src/main/java/com/dtalks/dtalks/news/repository/NewsRepository.java
@@ -1,0 +1,8 @@
+package com.dtalks.dtalks.news.repository;
+
+import com.dtalks.dtalks.news.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+    News findByUrl(String url);
+}

--- a/src/main/java/com/dtalks/dtalks/news/service/NewsService.java
+++ b/src/main/java/com/dtalks/dtalks/news/service/NewsService.java
@@ -6,4 +6,7 @@ import java.util.List;
 
 public interface NewsService {
     List<News> getNews();
+
+    List<News> saveNews();
+
 }

--- a/src/main/java/com/dtalks/dtalks/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/news/service/NewsServiceImpl.java
@@ -4,6 +4,7 @@ import com.dtalks.dtalks.exception.ErrorCode;
 import com.dtalks.dtalks.exception.exception.CustomException;
 import com.dtalks.dtalks.news.entity.News;
 import com.dtalks.dtalks.news.entity.NewsCrawler;
+import com.dtalks.dtalks.news.repository.NewsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,13 +15,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NewsServiceImpl implements NewsService {
     private final NewsCrawler newsCrawler;
-
-
+    private final NewsRepository newsRepository;
     @Override
     public List<News> getNews() {
         try {
             List<News> newsList = newsCrawler.crawlNews();
             return newsList;
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "뉴스가 존재하지 않습니다. ");
+        }
+    }
+
+    @Override
+    public List<News> saveNews() {
+        try {
+            List<News> newsList = newsCrawler.crawlNews();
+            return newsRepository.saveAll(newsList);
         } catch (IOException e) {
             throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "뉴스가 존재하지 않습니다. ");
         }

--- a/src/main/java/com/dtalks/dtalks/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/news/service/NewsServiceImpl.java
@@ -18,12 +18,12 @@ public class NewsServiceImpl implements NewsService {
     private final NewsRepository newsRepository;
     @Override
     public List<News> getNews() {
-        try {
-            List<News> newsList = newsCrawler.crawlNews();
-            return newsList;
-        } catch (IOException e) {
-            throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "뉴스가 존재하지 않습니다. ");
+        List<News> newsList = newsRepository.findTop20ByOrderByDateDesc();
+        if (newsList.isEmpty()) {
+            throw new CustomException(ErrorCode.POST_NOT_FOUND_ERROR, "최신 뉴스가 존재하지 않습니다. ");
         }
+
+        return newsList;
     }
 
     @Override


### PR DESCRIPTION
1. Crawling 정보를 DB에 저장하지 않고 불러오던것 -> DB 저장 api, DB 조회 api 로 수정
2. get /news -> 저장된 News중 최신 20개 list로 받아옴
3. post /news -> BLOTER 사이트의 IT 기업 new 기사(제목, 내용, 작성자, 날짜, 이미지 주소, 링크) 반환