### PR TITLE
fix:post s3에서 이미지 삭제 path 이용, 게시글 작성 or 수정 시 modelAttribute이용

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
@@ -14,9 +14,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -78,20 +78,17 @@ public class PostController {
     }
 
 
-    @Operation(summary = "게시글 생성")
-    @PostMapping
-    public ResponseEntity<Long> createPost(@Valid @RequestPart PostRequestDto postDto,
-                                           @RequestPart (required = false) List<MultipartFile> files) {
-        return ResponseEntity.ok(postService.createPost(postDto, files));
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Long> createPost(@Valid PostRequestDto postDto) {
+        return ResponseEntity.ok(postService.createPost(postDto));
     }
 
 
     @Operation(summary = "게시글 수정")
-    @PutMapping("/{id}")
-    public ResponseEntity<Long> updatePost(@Valid @RequestPart PostRequestDto postDto,
-                                           @RequestPart (required = false) List<MultipartFile> files,
+    @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Long> updatePost(@Valid PostRequestDto postDto,
                                            @PathVariable Long id) {
-        return ResponseEntity.ok(postService.updatePost(postDto, files, id));
+        return ResponseEntity.ok(postService.updatePost(postDto, id));
     }
 
 

--- a/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
@@ -28,7 +28,7 @@ public class PostDto {
     private String content;
 
     @Schema(description = "이미지 urls")
-    private List<String> urls;
+    private List<String> imageUrls;
 
     @Schema(description = "게시글을 작성한 사용자의 닉네임")
     @NotBlank

--- a/src/main/java/com/dtalks/dtalks/board/post/dto/PostRequestDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/dto/PostRequestDto.java
@@ -1,13 +1,22 @@
 package com.dtalks.dtalks.board.post.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class PostRequestDto {
     @NotBlank
     private String title;
 
     @NotBlank
     private String content;
+
+    @Schema(description = "게시글 첨부파일(이미지), 없어도 됨", example = "[첨부파일, 첨부파일]", nullable = true)
+    private List<MultipartFile> files;
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
@@ -4,7 +4,6 @@ import com.dtalks.dtalks.board.post.dto.PostDto;
 import com.dtalks.dtalks.board.post.dto.PostRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -16,8 +15,8 @@ public interface PostService {
 
     List<PostDto> search5BestPosts();
 
-    Long createPost(PostRequestDto postDto, List<MultipartFile> files);
-    Long updatePost(PostRequestDto postDto, List<MultipartFile> files, Long id);
+    Long createPost(PostRequestDto postDto);
+    Long updatePost(PostRequestDto postDto, Long id);
     void deletePost(Long id);
 
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -109,6 +109,7 @@ public class PostServiceImpl implements PostService {
                 Document document = Document.builder()
                         .inputName(file.getOriginalFilename())
                         .url(s3Uploader.fileUpload(file, path))
+                        .path(path)
                         .build();
                 documentRepository.save(document);
 
@@ -171,7 +172,7 @@ public class PostServiceImpl implements PostService {
                     }
                     if (isDeleted) {
                         imageRepository.delete(dbFile);
-                        s3Uploader.deleteFile(dbFile.getDocument().getUrl());
+                        s3Uploader.deleteFile(dbFile.getDocument().getPath());
                     } else {
                         dbInputNameList.add(inputName);
                     }
@@ -194,6 +195,7 @@ public class PostServiceImpl implements PostService {
                 Document document = Document.builder()
                         .inputName(file.getOriginalFilename())
                         .url(path)
+                        .path(path)
                         .build();
                 documentRepository.save(document);
 
@@ -238,7 +240,7 @@ public class PostServiceImpl implements PostService {
 
         List<PostImage> imageList = imageRepository.findByPostId(postId);
         for (PostImage image : imageList) {
-            s3Uploader.deleteFile(image.getDocument().getUrl());
+            s3Uploader.deleteFile(image.getDocument().getPath());
         }
 
         postRepository.delete(post);


### PR DESCRIPTION
1. 게시글 작성, 수정 시 document에 s3 path 추가
2. 게시글 수정, 삭제 시 s3에서 이미지 삭제 필요할 때 url이 아닌 path를 이용하도록 수정
3. 게시글 작성, 수정 시에 데이터 매핑 방법을 RequestPart에서 **modelAttribute로 변경** (multipart/form-data 지정하고 json데이터에 따로 application/json 넣어주는 방식이 아닌 **multipart/form-data만 content-type에 넣어주면 됨**)