### PR TITLE
fix: 게시글, 댓글 응답 dto에 사용자 이미지 추가, 댓글 질문 답변에 생성일 추가

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentInfoDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentInfoDto.java
@@ -1,6 +1,8 @@
 package com.dtalks.dtalks.board.comment.dto;
 
 import com.dtalks.dtalks.board.comment.entity.Comment;
+import com.dtalks.dtalks.user.dto.UserSimpleDto;
+import com.dtalks.dtalks.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -26,9 +28,8 @@ public class CommentInfoDto {
     @NotBlank
     String content;
 
-    @Schema(description = "댓글을 단 사용자의 닉네임")
-    @NotBlank
-    String nickname;
+    @Schema(description = "작성한 사용자의 닉네임, 이미지")
+    UserSimpleDto userInfo;
 
     @Schema(description = "비밀글 여부. true일 경우 사용자와 게시글 주인만 볼 수 있도록 처리하면 됨")
     boolean isSecret;
@@ -53,11 +54,14 @@ public class CommentInfoDto {
 
     @Builder
     public static CommentInfoDto toDto(Comment comment) {
+        User user = comment.getUser();
+        String profile = (user.getProfileImage() != null ? user.getProfileImage().getUrl() : null);
+
         return CommentInfoDto.builder()
                 .id(comment.getId())
                 .postId(comment.getPost().getId())
                 .content(comment.isRemoved() ? "삭제된 댓글입니다." : comment.getContent())
-                .nickname(comment.getUser().getNickname())
+                .userInfo(UserSimpleDto.createUserInfo(user.getNickname(), profile))
                 .isSecret(comment.isSecret())
                 .isRemoved(comment.isRemoved())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)

--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentInfoDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentInfoDto.java
@@ -1,10 +1,12 @@
 package com.dtalks.dtalks.board.comment.dto;
 
 import com.dtalks.dtalks.board.comment.entity.Comment;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +45,12 @@ public class CommentInfoDto {
     @Schema(description = "자식 댓글 리스트. 자신이 부모 댓글일 경우 자식 댓글 리스트 필요")
     List<CommentInfoDto> childrenList = new ArrayList<>();
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDate;
+
     @Builder
     public static CommentInfoDto toDto(Comment comment) {
         return CommentInfoDto.builder()
@@ -55,6 +63,8 @@ public class CommentInfoDto {
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .parentNickname(comment.getParent() != null ? comment.getParent().getUser().getNickname() : null)
                 .childrenList(new ArrayList<>())
+                .createDate(comment.getCreateDate())
+                .modifiedDate(comment.getModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentInfoDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentInfoDto.java
@@ -32,10 +32,10 @@ public class CommentInfoDto {
     UserSimpleDto userInfo;
 
     @Schema(description = "비밀글 여부. true일 경우 사용자와 게시글 주인만 볼 수 있도록 처리하면 됨")
-    boolean isSecret;
+    boolean secret;
 
     @Schema(description = "댓글 삭제 여부. 사용자가 댓글을 삭제했는데 자식 댓글이 달려있는 경우로 true일 때 '삭제된 댓글입니다.'로 content에 들어가있음.")
-    boolean isRemoved;
+    boolean remove;
 
     @Schema(description = "부모댓글의 id. 자식 댓글일 경우 부모 댓글 필요.")
     Long parentId;
@@ -62,8 +62,8 @@ public class CommentInfoDto {
                 .postId(comment.getPost().getId())
                 .content(comment.isRemoved() ? "삭제된 댓글입니다." : comment.getContent())
                 .userInfo(UserSimpleDto.createUserInfo(user.getNickname(), profile))
-                .isSecret(comment.isSecret())
-                .isRemoved(comment.isRemoved())
+                .secret(comment.isSecret())
+                .remove(comment.isRemoved())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .parentNickname(comment.getParent() != null ? comment.getParent().getUser().getNickname() : null)
                 .childrenList(new ArrayList<>())

--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/CommentRequestDto.java
@@ -11,5 +11,5 @@ public class CommentRequestDto {
     String content;
 
     @Schema(description = "비밀글 여부.")
-    boolean isSecret;
+    boolean secret;
 }

--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/UserCommentDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/UserCommentDto.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Setter
@@ -35,6 +33,8 @@ public class UserCommentDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createDate;
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDate;
     @Builder
     public static UserCommentDto toDto(Comment comment, Long postId, String title) {
         return UserCommentDto.builder()
@@ -44,6 +44,7 @@ public class UserCommentDto {
                 .content(comment.getContent())
                 .isSecret(comment.isSecret())
                 .createDate(comment.getCreateDate())
+                .modifiedDate(comment.getModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/board/comment/dto/UserCommentDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/dto/UserCommentDto.java
@@ -28,7 +28,7 @@ public class UserCommentDto {
     String content;
 
     @Schema(description = "비밀글 여부")
-    boolean isSecret;
+    boolean secret;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createDate;
@@ -42,7 +42,7 @@ public class UserCommentDto {
                 .postId(postId)
                 .postTitle(title)
                 .content(comment.getContent())
-                .isSecret(comment.isSecret())
+                .secret(comment.isSecret())
                 .createDate(comment.getCreateDate())
                 .modifiedDate(comment.getModifiedDate())
                 .build();

--- a/src/main/java/com/dtalks/dtalks/board/comment/entity/Comment.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/entity/Comment.java
@@ -30,9 +30,9 @@ public class Comment extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    private boolean isSecret;
+    private boolean secret;
 
-    private boolean isRemoved;
+    private boolean removed;
 
     // 부모 댓글
     @ManyToOne(fetch = FetchType.LAZY)
@@ -41,4 +41,9 @@ public class Comment extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "parent", orphanRemoval = true)
     private List<Comment> childList = new ArrayList<>();
+
+    public void updateComment(String content, boolean secret) {
+        this.content = content;
+        this.secret = secret;
+    }
 }

--- a/src/main/java/com/dtalks/dtalks/board/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/repository/CommentRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long postId);
-    List<Comment> findByUserIdAndIsRemovedFalse(Long userId);
+    List<Comment> findByUserIdAndRemovedFalse(Long userId);
 }

--- a/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
@@ -78,7 +78,7 @@ public class CommentServiceImpl implements CommentService{
     @Transactional(readOnly = true)
     public List<UserCommentDto> searchListByUserId(String userId) {
         User user = findUser(userId);
-        List<Comment> commentList = commentRepository.findByUserIdAndIsRemovedFalse(user.getId());
+        List<Comment> commentList = commentRepository.findByUserIdAndRemovedFalse(user.getId());
         return commentList.stream().map(c -> {
             Post post = c.getPost();
             return UserCommentDto.toDto(c, post.getId(), post.getTitle());
@@ -94,7 +94,7 @@ public class CommentServiceImpl implements CommentService{
 
         Comment comment = Comment.builder()
                 .content(dto.getContent())
-                .isSecret(dto.isSecret())
+                .secret(dto.isSecret())
                 .user(user)
                 .post(post)
                 .build();
@@ -119,7 +119,7 @@ public class CommentServiceImpl implements CommentService{
 
         Comment comment = Comment.builder()
                 .content(dto.getContent())
-                .isSecret(dto.isSecret())
+                .secret(dto.isSecret())
                 .user(user)
                 .post(post)
                 .parent(parentComment)
@@ -146,9 +146,7 @@ public class CommentServiceImpl implements CommentService{
         if (!comment.getUser().getUserid().equals(currentUserId)) {
             throw new CustomException(ErrorCode.PERMISSION_NOT_GRANTED_ERROR, "해당 댓글을 수정할 권한이 없습니다.");
         }
-
-        comment.setContent(dto.getContent());
-        comment.setSecret(dto.isSecret());
+        comment.updateComment(dto.getContent(), dto.isSecret());
     }
 
     @Override
@@ -173,7 +171,7 @@ public class CommentServiceImpl implements CommentService{
 
         /**
          * 삭제하려는 댓글의 자식 댓글이 있는 경우
-         * db에서 삭제가 아닌 '삭제된 댓글입니다.'로 표시하기 위해 isRemoved = true로 변경
+         * db에서 삭제가 아닌 '삭제된 댓글입니다.'로 표시하기 위해 removed = true로 변경
          */
         if (comment.getChildList().size() != 0) {
             comment.setRemoved(true);

--- a/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/dto/PostDto.java
@@ -1,11 +1,12 @@
 package com.dtalks.dtalks.board.post.dto;
 
 import com.dtalks.dtalks.board.post.entity.Post;
+import com.dtalks.dtalks.user.dto.UserSimpleDto;
+import com.dtalks.dtalks.user.entity.User;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
-import org.springframework.core.io.Resource;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,9 +31,8 @@ public class PostDto {
     @Schema(description = "이미지 urls")
     private List<String> imageUrls;
 
-    @Schema(description = "게시글을 작성한 사용자의 닉네임")
-    @NotBlank
-    private String nickname;
+    @Schema(description = "작성한 사용자의 닉네임, 이미지")
+    UserSimpleDto userInfo;
 
     @Schema(description = "게시글의 댓글수")
     private Integer commentCount;
@@ -54,11 +54,14 @@ public class PostDto {
 
     @Builder
     public static PostDto toDto(Post post) {
+        User user = post.getUser();
+        String profile = (user.getProfileImage() != null ? user.getProfileImage().getUrl() : null);
+
         return PostDto.builder()
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .nickname(post.getUser().getNickname())
+                .userInfo(UserSimpleDto.createUserInfo(user.getNickname(), profile))
                 .commentCount(post.getCommentCount())
                 .viewCount(post.getViewCount())
                 .favoriteCount(post.getFavoriteCount())

--- a/src/main/java/com/dtalks/dtalks/qna/answer/dto/AnswerResponseDto.java
+++ b/src/main/java/com/dtalks/dtalks/qna/answer/dto/AnswerResponseDto.java
@@ -1,11 +1,14 @@
 package com.dtalks.dtalks.qna.answer.dto;
 
 import com.dtalks.dtalks.qna.answer.entity.Answer;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -20,12 +23,20 @@ public class AnswerResponseDto {
     @NotBlank
     private String nickname;
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDate;
+
     @Builder
     public static AnswerResponseDto toDto(Answer answer) {
         return AnswerResponseDto.builder()
                 .id(answer.getId())
                 .content(answer.getContent())
                 .nickname(answer.getUser().getNickname())
+                .createDate(answer.getCreateDate())
+                .modifiedDate(answer.getModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/qna/question/dto/QuestionResponseDto.java
+++ b/src/main/java/com/dtalks/dtalks/qna/question/dto/QuestionResponseDto.java
@@ -1,11 +1,14 @@
 package com.dtalks.dtalks.qna.question.dto;
 
 import com.dtalks.dtalks.qna.question.entity.Question;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -25,6 +28,12 @@ public class QuestionResponseDto {
 
     private Integer likeCount;
 
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime modifiedDate;
+
     @Builder
     public static QuestionResponseDto toDto(Question question) {
         return QuestionResponseDto.builder()
@@ -33,6 +42,8 @@ public class QuestionResponseDto {
                 .content(question.getContent())
                 .nickname(question.getUser().getNickname())
                 .likeCount(question.getLikeCount())
+                .createDate(question.getCreateDate())
+                .modifiedDate(question.getModifiedDate())
                 .build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/user/dto/UserSimpleDto.java
+++ b/src/main/java/com/dtalks/dtalks/user/dto/UserSimpleDto.java
@@ -1,0 +1,30 @@
+package com.dtalks.dtalks.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "게시글, 댓글 등에 쓰이는 사용자 관련 정보 dto")
+public class UserSimpleDto {
+
+    @NotBlank
+    @Schema(description = "작성한 사용자의 닉네임")
+    private String nickname;
+
+    @Schema(description = "사용자 이미지")
+    private String userProfile;
+
+    @Builder
+    public static UserSimpleDto createUserInfo(String nickname, String userProfile) {
+        return UserSimpleDto.builder()
+                .nickname(nickname)
+                .userProfile(userProfile)
+                .build();
+    }
+
+}


### PR DESCRIPTION
1. 댓글, 질문, 답변 응답 dto에 작성일, 수정일 추가
2. 사용자 닉네임과 이미지만 응답 dto에서 공통적으로 쓰일 것으로 예상해 관련 내용만 가지고 있는 UserSimpleDto 파일 생성
3. 게시글, 댓글 응답 dto에서 사용자 관련 내용은 userInfo로 전달(nickname, profile)
4. 댓글 비밀 설정 수정 (entity, dto에서 boolean인 필드 isSecret, isRemoved -> secret, removed로 변경) **db 수정 필요**