### PR TITLE
feat: 유저 아이디/비밀번호 찾기, redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
 	// s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dtalks/dtalks/base/config/RedisConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/base/config/RedisConfiguration.java
@@ -1,0 +1,32 @@
+package com.dtalks.dtalks.base.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfiguration {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/user/config/SecurityConfiguration.java
@@ -45,6 +45,7 @@ public class SecurityConfiguration {
                 .requestMatchers(HttpMethod.GET, "/questions/**", "/answers/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/users/profile/image").permitAll()
                 .requestMatchers(HttpMethod.GET, "/news").permitAll()
+                .requestMatchers(HttpMethod.GET, "/users/userid").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())

--- a/src/main/java/com/dtalks/dtalks/user/controller/EmailController.java
+++ b/src/main/java/com/dtalks/dtalks/user/controller/EmailController.java
@@ -1,7 +1,10 @@
 package com.dtalks.dtalks.user.controller;
 
+import com.dtalks.dtalks.user.dto.AccessTokenDto;
 import com.dtalks.dtalks.user.dto.EmailVerifyResponseDto;
+import com.dtalks.dtalks.user.dto.UserEmailDto;
 import com.dtalks.dtalks.user.service.EmailService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,13 +23,24 @@ public class EmailController {
         this.emailService = emailService;
     }
 
-    @GetMapping("/verify")
-    public ResponseEntity<EmailVerifyResponseDto> emailVerify(@RequestParam String email) throws Exception{
+    @Operation(summary = "이메일 인증번호 발송")
+    @PostMapping("/verify")
+    public ResponseEntity<EmailVerifyResponseDto> sendEmailVerify(@RequestBody UserEmailDto userEmailDto) throws Exception{
         LOGGER.info("emailVerify 호출됨");
-        String code = emailService.sendEmailAuthenticationCode(email);
-        EmailVerifyResponseDto emailVerifyResponseDto = new EmailVerifyResponseDto();
-        emailVerifyResponseDto.setEmail(email);
-        emailVerifyResponseDto.setCode(code);
-        return ResponseEntity.ok(emailVerifyResponseDto);
+        String code = emailService.sendEmailAuthenticationCode(userEmailDto.getEmail());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "이메일 인증번호 확인")
+    @GetMapping("/verify")
+    public ResponseEntity emailVerify(@RequestParam String code) {
+        emailService.checkEmailVerify(code);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "비밀번호 찾기를 위한 이메일 인증번호 확인")
+    @GetMapping("/password/verify")
+    public ResponseEntity<AccessTokenDto> passwordEmailVerify(@RequestParam String code) {
+        return ResponseEntity.ok(emailService.checkEmailVerifyPassword(code));
     }
 }

--- a/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
+++ b/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
@@ -1,21 +1,18 @@
 package com.dtalks.dtalks.user.controller;
 
 import com.dtalks.dtalks.base.dto.DocumentResponseDto;
-import com.dtalks.dtalks.studyroom.enums.Skill;
 import com.dtalks.dtalks.user.dto.*;
 import com.dtalks.dtalks.user.entity.User;
 import com.dtalks.dtalks.user.service.UserDetailsService;
 import com.dtalks.dtalks.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -25,9 +22,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.util.List;
 
 @Tag(name = "users")
 @RestController
@@ -156,5 +150,19 @@ public class UserController {
             @RequestBody @Valid UserEmailDto userEmailDto
     ) {
         return ResponseEntity.ok(userService.updateUserEmail(userEmailDto));
+    }
+
+    @Operation(summary = "유저 아이디 찾기")
+    @GetMapping(value = "/userid")
+    public ResponseEntity findUserid(@RequestParam String email) {
+        userService.findUserid(email);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "유저 비밀번호 찾기(변경)")
+    @PutMapping(value = "/password")
+    public ResponseEntity findUserPassword(HttpServletRequest request, @RequestBody UserPasswordFindDto userPasswordFindDto) {
+        userService.findUserPassword(request, userPasswordFindDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dtalks/dtalks/user/dto/AccessTokenDto.java
+++ b/src/main/java/com/dtalks/dtalks/user/dto/AccessTokenDto.java
@@ -1,0 +1,11 @@
+package com.dtalks.dtalks.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class AccessTokenDto {
+
+    private String accessToken;
+}

--- a/src/main/java/com/dtalks/dtalks/user/dto/UserPasswordFindDto.java
+++ b/src/main/java/com/dtalks/dtalks/user/dto/UserPasswordFindDto.java
@@ -1,0 +1,20 @@
+package com.dtalks.dtalks.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class UserPasswordFindDto {
+    @Schema(description = "비밀번호")
+    @Pattern(regexp = "(?=.*\\W)(?=\\S+$).{8,15}",
+            message = "특수기호가 적어도 1개 이상 포함된 5~15자의 비밀번호이어야 합니다.")
+    @NotBlank
+    private String newPassword;
+
+    @Schema(description = "비밀번호 확인")
+    private String checkNewPassword;
+}

--- a/src/main/java/com/dtalks/dtalks/user/entity/AccessTokenPassword.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/AccessTokenPassword.java
@@ -1,0 +1,17 @@
+package com.dtalks.dtalks.user.entity;
+
+import lombok.AllArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
+
+@RedisHash(value = "accessToken", timeToLive = 300)
+@AllArgsConstructor
+public class AccessTokenPassword {
+
+    @Id
+    private String accessToken;
+
+    private LocalDateTime createDate;
+}

--- a/src/main/java/com/dtalks/dtalks/user/entity/EmailAuthentication.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/EmailAuthentication.java
@@ -1,0 +1,24 @@
+package com.dtalks.dtalks.user.entity;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
+
+@RedisHash(value = "email", timeToLive = 300)
+@Getter
+@AllArgsConstructor
+public class EmailAuthentication {
+
+    @Id
+    private String code;
+
+    private String email;
+
+    private LocalDateTime createDate;
+}

--- a/src/main/java/com/dtalks/dtalks/user/repository/AccessTokenPasswordRepository.java
+++ b/src/main/java/com/dtalks/dtalks/user/repository/AccessTokenPasswordRepository.java
@@ -1,0 +1,7 @@
+package com.dtalks.dtalks.user.repository;
+
+import com.dtalks.dtalks.user.entity.AccessTokenPassword;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AccessTokenPasswordRepository extends CrudRepository<AccessTokenPassword, String> {
+}

--- a/src/main/java/com/dtalks/dtalks/user/repository/EmailAuthenticationRepository.java
+++ b/src/main/java/com/dtalks/dtalks/user/repository/EmailAuthenticationRepository.java
@@ -1,0 +1,7 @@
+package com.dtalks.dtalks.user.repository;
+
+import com.dtalks.dtalks.user.entity.EmailAuthentication;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailAuthenticationRepository extends CrudRepository<EmailAuthentication, String> {
+}

--- a/src/main/java/com/dtalks/dtalks/user/service/EmailService.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/EmailService.java
@@ -1,5 +1,16 @@
 package com.dtalks.dtalks.user.service;
 
+import com.dtalks.dtalks.user.dto.AccessTokenDto;
+import jakarta.mail.internet.MimeMessage;
+
 public interface EmailService {
     String sendEmailAuthenticationCode(String email) throws Exception;
+
+    void checkEmailVerify(String code);
+
+    AccessTokenDto checkEmailVerifyPassword(String code);
+
+    void sendEmail(MimeMessage mimeMessage);
+
+    MimeMessage createUseridMessage(String email, String userid);
 }

--- a/src/main/java/com/dtalks/dtalks/user/service/EmailServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/EmailServiceImpl.java
@@ -1,34 +1,126 @@
 package com.dtalks.dtalks.user.service;
 
+import com.dtalks.dtalks.exception.ErrorCode;
+import com.dtalks.dtalks.exception.exception.CustomException;
+import com.dtalks.dtalks.user.dto.AccessTokenDto;
+import com.dtalks.dtalks.user.dto.UserTokenDto;
+import com.dtalks.dtalks.user.entity.AccessTokenPassword;
+import com.dtalks.dtalks.user.entity.EmailAuthentication;
+import com.dtalks.dtalks.user.entity.User;
+import com.dtalks.dtalks.user.repository.AccessTokenPasswordRepository;
+import com.dtalks.dtalks.user.repository.EmailAuthenticationRepository;
+import com.dtalks.dtalks.user.repository.UserRepository;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import java.io.UnsupportedEncodingException;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.Random;
 
 @Service
+@RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService{
 
-    @Autowired
-    JavaMailSender javaMailSender;
+    private final JavaMailSender javaMailSender;
+    private final EmailAuthenticationRepository emailAuthenticationRepository;
+    private final AccessTokenPasswordRepository accessTokenPasswordRepository;
+    private final UserRepository userRepository;
+    private final TokenService tokenService;
 
-    public EmailServiceImpl(JavaMailSender javaMailSender) {
-        this.javaMailSender = javaMailSender;
+    @Override
+    public String sendEmailAuthenticationCode(String email) {
+        try {
+            String code = createCode();
+            MimeMessage mimeMessage = createMessage(email, code);
+            javaMailSender.send(mimeMessage);
+            EmailAuthentication emailAuthentication = new EmailAuthentication(code, email, LocalDateTime.now());
+            emailAuthenticationRepository.save(emailAuthentication);
+            return code;
+        }
+        catch (MessagingException e) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "이메일 발송에 실패하였습니다.");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "이메일 발송에 실패하였습니다.");
+        }
     }
 
     @Override
-    public String sendEmailAuthenticationCode(String email) throws MessagingException, UnsupportedEncodingException, MailException {
-        String code = createCode();
-        MimeMessage mimeMessage = createMessage(email, code);
-        javaMailSender.send(mimeMessage);
+    public void checkEmailVerify(String code) {
+        Optional<EmailAuthentication> optionalEmailAuthentication = emailAuthenticationRepository.findById(code);
+        if(optionalEmailAuthentication.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "인증번호가 틀렸습니다.");
+        }
+    }
 
-        return code;
+    @Override
+    public AccessTokenDto checkEmailVerifyPassword(String code) {
+        Optional<EmailAuthentication> optionalEmailAuthentication = emailAuthenticationRepository.findById(code);
+        if(optionalEmailAuthentication.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "인증번호가 틀렸습니다.");
+        }
+
+        Optional<User> optionalUser = userRepository.findByEmail(optionalEmailAuthentication.get().getEmail());
+        if(optionalUser.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "존재하지 않는 유저입니다.");
+        }
+
+
+        UserTokenDto userTokenDto = UserTokenDto.toDto(optionalUser.get());
+        String accessToken = tokenService.createAccessToken(userTokenDto);
+        AccessTokenDto accessTokenDto = new AccessTokenDto();
+        accessTokenDto.setAccessToken(accessToken);
+
+        AccessTokenPassword accessTokenPassword = new AccessTokenPassword(accessToken, LocalDateTime.now());
+        accessTokenPasswordRepository.save(accessTokenPassword);
+
+        return accessTokenDto;
+    }
+
+    @Override
+    public void sendEmail(MimeMessage mimeMessage) {
+        javaMailSender.send(mimeMessage);
+    }
+
+    @Override
+    public MimeMessage createUseridMessage(String email, String userid) {
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            mimeMessage.addRecipients(Message.RecipientType.TO, email);
+            mimeMessage.setSubject("d-talks 아이디 찾기");
+
+            StringBuffer message = new StringBuffer();
+            message.append("<div style='margin:20px;'>");
+            message.append("<h1> 안녕하세요 d-talks 입니다. </h1>");
+            message.append("<br>");
+            message.append("<p>회원님의 아이디는 다음과 같습니다.<p>");
+            message.append("<br>");
+            message.append("감사합니다.");
+            message.append("<div align='center' style='border:1px solid black; font-family:verdana';>");
+            message.append("<h3 style='color:blue;'>회원님의 아이디 입니다.</h3>");
+            message.append("<div style='font-size:130%'>");
+            message.append(userid + "</strong><div><br/> ");
+            message.append("</div>");
+
+            mimeMessage.setText(message.toString(), "utf-8", "html");
+            mimeMessage.setFrom(new InternetAddress("rladydgn7575@gmail.com", "d-talks"));
+
+            return mimeMessage;
+        }
+        catch (MessagingException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "이메일 발송 실패");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "이메일 발송 실패");
+        }
     }
 
     private MimeMessage createMessage(String email, String code) throws MessagingException, UnsupportedEncodingException {

--- a/src/main/java/com/dtalks/dtalks/user/service/UserService.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.dtalks.dtalks.user.service;
 import com.dtalks.dtalks.base.dto.DocumentResponseDto;
 import com.dtalks.dtalks.studyroom.enums.Skill;
 import com.dtalks.dtalks.user.dto.*;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -49,4 +50,8 @@ public interface UserService {
     SignInResponseDto updateUserPassword(UserPasswordDto userPasswordDto);
 
     SignInResponseDto updateUserEmail(UserEmailDto userEmailDto);
+
+    void findUserid(String email);
+
+    void findUserPassword(HttpServletRequest request, UserPasswordFindDto userPasswordFindDto);
 }

--- a/src/main/java/com/dtalks/dtalks/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserServiceImpl.java
@@ -12,16 +12,22 @@ import com.dtalks.dtalks.qna.question.entity.Question;
 import com.dtalks.dtalks.user.Util.SecurityUtil;
 import com.dtalks.dtalks.user.common.CommonResponse;
 import com.dtalks.dtalks.user.dto.*;
+import com.dtalks.dtalks.user.entity.AccessTokenPassword;
 import com.dtalks.dtalks.user.entity.Activity;
 import com.dtalks.dtalks.user.entity.User;
 import com.dtalks.dtalks.user.enums.ActivityType;
+import com.dtalks.dtalks.user.repository.AccessTokenPasswordRepository;
 import com.dtalks.dtalks.user.repository.ActivityRepository;
 import com.dtalks.dtalks.user.repository.UserRepository;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +49,8 @@ public class UserServiceImpl implements UserService {
     private final DocumentRepository documentRepository;
     private final ActivityRepository activityRepository;
     private final S3Uploader s3Uploader;
+    private final EmailService emailService;
+    private final AccessTokenPasswordRepository accessTokenPasswordRepository;
     private final String imagePath =  "profiles";
 
     @Override
@@ -452,6 +460,33 @@ public class UserServiceImpl implements UserService {
         signInResponseDto.setAccessToken(accessToken);
         signInResponseDto.setRefreshToken(refreshToken);
         return signInResponseDto;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void findUserid(String email) {
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+        if(optionalUser.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "가입되지 않은 이메일입니다.");
+        }
+
+        User user = optionalUser.get();
+
+        MimeMessage mimeMessage = emailService.createUseridMessage(user.getEmail(), user.getUserid());
+        emailService.sendEmail(mimeMessage);
+    }
+
+    @Override
+    @Transactional
+    public void findUserPassword(HttpServletRequest httpServletRequest, UserPasswordFindDto userPasswordFindDto) {
+        Optional<AccessTokenPassword> optionalAccessTokenPassword = accessTokenPasswordRepository.findById(tokenService.resolveToken(httpServletRequest));
+        if(optionalAccessTokenPassword.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "인증되지 않은 토큰입니다.");
+        }
+
+        User user = SecurityUtil.getUser();
+        user.setPassword(passwordEncoder.encode(userPasswordFindDto.getNewPassword()));
+        userRepository.save(user);
     }
 
     private void setSuccessResult(SignUpResponseDto result) {

--- a/src/test/java/com/dtalks/dtalks/user/service/EmailServiceImplTest.java
+++ b/src/test/java/com/dtalks/dtalks/user/service/EmailServiceImplTest.java
@@ -1,0 +1,39 @@
+package com.dtalks.dtalks.user.service;
+
+import com.dtalks.dtalks.user.entity.EmailAuthentication;
+import com.dtalks.dtalks.user.repository.EmailAuthenticationRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class EmailServiceImplTest {
+
+    @Autowired
+    EmailService emailService;
+    @Autowired
+    EmailAuthenticationRepository emailAuthenticationRepository;
+
+    @AfterEach
+    void afterEach() {
+        emailAuthenticationRepository.deleteAll();
+    }
+
+    @Test
+    void sendEmailAuthenticationCode_success() throws Exception{
+        // given
+        String email = "dhdgn@naver.com";
+
+        // when
+        String code = emailService.sendEmailAuthenticationCode(email);
+
+        // then
+        emailService.checkEmailVerify(code);
+    }
+}


### PR DESCRIPTION
- 유저 아이디 찾기 api
    - 이메일로 유저 아이디 발송
- 유저 비밀번호 찾기(변경) api
    - 이메일 인증 완료하면 accesstoken 발급, 기존 accesstoken과 구분하기 위해 redis에도 저장되어 추가 검증을 진행함.
    - 인증 완료되면 새로운 비밀번호 입력을 통해 비밀번호 변경함
- redis 추가
- 이메일 인증 백엔드에서 검증하도록 변경