### PR TITLE
feat: 채팅 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// chat
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.webjars:stomp-websocket:2.3.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dtalks/dtalks/studyroom/config/WebSocketConfiguration.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/config/WebSocketConfiguration.java
@@ -1,0 +1,26 @@
+package com.dtalks.dtalks.studyroom.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독자 클라이언트들에게 메세지 보낼때
+        registry.enableSimpleBroker("/sub");
+        // 클라이언트에서 보낸 메세지 받을때
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/controller/ChatController.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/controller/ChatController.java
@@ -1,0 +1,39 @@
+package com.dtalks.dtalks.studyroom.controller;
+
+import com.dtalks.dtalks.studyroom.dto.ChatMessageDto;
+import com.dtalks.dtalks.studyroom.dto.ChatMessageRequestDto;
+import com.dtalks.dtalks.studyroom.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @MessageMapping("/{chatRoomId}")
+    @SendTo("/rooms/{chatRoomId}")
+    public ChatMessageDto message(@DestinationVariable Long chatRoomId, ChatMessageRequestDto chatMessageRequestDto) {
+        return chatService.createChatMessage(chatRoomId, chatMessageRequestDto.getMessage());
+    }
+
+    @Operation(summary = "채팅 가져오기")
+    @GetMapping("/{chatRoomId}/chats")
+    public ResponseEntity<Page<ChatMessageDto>> searchAll(
+            @PageableDefault(size = 100, sort = "createDate", direction = Sort.Direction.DESC) @ParameterObject Pageable pageable,
+            @PathVariable Long chatRoomId
+            ) {
+        return ResponseEntity.ok(chatService.findAllChat(chatRoomId, pageable));
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/controller/ChatController.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/controller/ChatController.java
@@ -22,7 +22,7 @@ public class ChatController {
 
     private final ChatService chatService;
 
-    @MessageMapping("/{chatRoomId}")
+    @MessageMapping("/rooms/{chatRoomId}")
     @SendTo("/rooms/{chatRoomId}")
     public ChatMessageDto message(@DestinationVariable Long chatRoomId, ChatMessageRequestDto chatMessageRequestDto) {
         return chatService.createChatMessage(chatRoomId, chatMessageRequestDto.getMessage());

--- a/src/main/java/com/dtalks/dtalks/studyroom/dto/ChatMessageDto.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/dto/ChatMessageDto.java
@@ -1,0 +1,31 @@
+package com.dtalks.dtalks.studyroom.dto;
+
+import com.dtalks.dtalks.studyroom.entity.ChatMessage;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+public class ChatMessageDto {
+
+    @Schema
+    private Long id;
+    private String sender;
+    private String message;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createDate;
+
+    public static ChatMessageDto toDto(ChatMessage chatMessage) {
+        return ChatMessageDto.builder()
+                .id(chatMessage.getId())
+                .sender(chatMessage.getSender().getNickname())
+                .message(chatMessage.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/dto/ChatMessageRequestDto.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/dto/ChatMessageRequestDto.java
@@ -1,0 +1,11 @@
+package com.dtalks.dtalks.studyroom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatMessageRequestDto {
+
+    private String message;
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/dto/ChatRoomDto.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/dto/ChatRoomDto.java
@@ -1,0 +1,21 @@
+package com.dtalks.dtalks.studyroom.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class ChatRoomDto {
+
+    private String roomId;
+    private String name;
+
+    public static ChatRoomDto create(String name) {
+        ChatRoomDto chatRoomDto = new ChatRoomDto();
+        chatRoomDto.setRoomId(UUID.randomUUID().toString());
+        chatRoomDto.setName(name);
+        return chatRoomDto;
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/entity/ChatMessage.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/entity/ChatMessage.java
@@ -1,0 +1,25 @@
+package com.dtalks.dtalks.studyroom.entity;
+
+import com.dtalks.dtalks.base.entity.BaseTimeEntity;
+import com.dtalks.dtalks.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class ChatMessage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private User sender;
+
+    private String message;
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/entity/ChatRoom.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/entity/ChatRoom.java
@@ -1,0 +1,19 @@
+package com.dtalks.dtalks.studyroom.entity;
+
+import com.dtalks.dtalks.base.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+public class ChatRoom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(orphanRemoval = true, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private StudyRoom studyRoom;
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/repository/ChatMessageRepository.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/repository/ChatMessageRepository.java
@@ -1,0 +1,12 @@
+package com.dtalks.dtalks.studyroom.repository;
+
+import com.dtalks.dtalks.studyroom.entity.ChatMessage;
+import com.dtalks.dtalks.studyroom.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    Page<ChatMessage> findByChatRoom(ChatRoom chatRoom, Pageable pageable);
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.dtalks.dtalks.studyroom.repository;
+
+import com.dtalks.dtalks.studyroom.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/ChatService.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/ChatService.java
@@ -1,0 +1,17 @@
+package com.dtalks.dtalks.studyroom.service;
+
+import com.dtalks.dtalks.studyroom.dto.ChatMessageDto;
+import com.dtalks.dtalks.studyroom.dto.ChatRoomDto;
+import com.dtalks.dtalks.studyroom.entity.ChatRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ChatService {
+
+
+    public ChatRoom createRoom(Long studyRoomId);
+
+    public ChatMessageDto createChatMessage(Long chatRoomId, String message);
+
+    public Page<ChatMessageDto> findAllChat(Long chatRoomId, Pageable pageable);
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/ChatServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/ChatServiceImpl.java
@@ -1,0 +1,89 @@
+package com.dtalks.dtalks.studyroom.service;
+
+import com.dtalks.dtalks.exception.ErrorCode;
+import com.dtalks.dtalks.exception.exception.CustomException;
+import com.dtalks.dtalks.studyroom.dto.ChatMessageDto;
+import com.dtalks.dtalks.studyroom.entity.ChatMessage;
+import com.dtalks.dtalks.studyroom.entity.ChatRoom;
+import com.dtalks.dtalks.studyroom.entity.StudyRoom;
+import com.dtalks.dtalks.studyroom.entity.StudyRoomUser;
+import com.dtalks.dtalks.studyroom.repository.ChatMessageRepository;
+import com.dtalks.dtalks.studyroom.repository.ChatRoomRepository;
+import com.dtalks.dtalks.studyroom.repository.StudyRoomRepository;
+import com.dtalks.dtalks.user.Util.SecurityUtil;
+import com.dtalks.dtalks.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatServiceImpl implements ChatService {
+
+    private final StudyRoomRepository studyRoomRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Override
+    public ChatRoom createRoom(Long studyRoomId) {
+        ChatRoom chatRoom = new ChatRoom();
+        Optional<StudyRoom> optionalStudyRoom = studyRoomRepository.findById(studyRoomId);
+        if(optionalStudyRoom.isEmpty()) {
+            throw new CustomException(ErrorCode.STUDYROOM_NOT_FOUND_ERROR, "스터디룸을 찾을수 없습니다.");
+        }
+
+        chatRoom.setStudyRoom(optionalStudyRoom.get());
+        chatRoomRepository.save(chatRoom);
+        return chatRoom;
+    }
+
+    @Override
+    @Transactional
+    public ChatMessageDto createChatMessage(Long chatRoomId, String message) {
+        User user = SecurityUtil.getUser();
+        ChatRoom chatRoom = checkChatRoom(chatRoomId);
+        checkStudyRoomMember(chatRoom.getStudyRoom(), user);
+
+        ChatMessage chatMessage = new ChatMessage();
+        chatMessage.setChatRoom(chatRoom);
+        chatMessage.setSender(user);
+        chatMessage.setMessage(message);
+        chatMessageRepository.save(chatMessage);
+
+        return ChatMessageDto.toDto(chatMessage);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ChatMessageDto> findAllChat(Long chatRoomId, Pageable pageable) {
+        User user = SecurityUtil.getUser();
+        ChatRoom chatRoom = checkChatRoom(chatRoomId);
+        checkStudyRoomMember(chatRoom.getStudyRoom(), user);
+        Page<ChatMessage> chatMessages = chatMessageRepository.findByChatRoom(chatRoom, pageable);
+        return chatMessages.map(ChatMessageDto::toDto);
+    }
+
+    private void checkStudyRoomMember(StudyRoom studyRoom, User user) {
+        for(StudyRoomUser studyRoomUser: studyRoom.getStudyRoomUsers()) {
+            if(studyRoomUser.getUser().getEmail().equals(user.getEmail())) {
+                return;
+            }
+        }
+        throw new CustomException(ErrorCode.VALIDATION_ERROR, "스터디룸 가입 유저가 아닙니다.");
+    }
+
+    private ChatRoom checkChatRoom(Long chatRoomId) {
+        Optional<ChatRoom> optionalChatRoom = chatRoomRepository.findById(chatRoomId);
+        if(optionalChatRoom.isEmpty()) {
+            throw new CustomException(ErrorCode.VALIDATION_ERROR, "채팅방이 존재하지 않습니다.");
+        }
+        return optionalChatRoom.get();
+    }
+}

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
@@ -43,6 +43,7 @@ public class StudyRoomServiceImpl implements StudyRoomService{
     private final UserRepository userRepository;
     private final ActivityRepository activityRepository;
     private final AlarmRepository alarmRepository;
+    private final ChatService chatService;
 
     @Override
     @Transactional
@@ -56,6 +57,7 @@ public class StudyRoomServiceImpl implements StudyRoomService{
         studyRoomUsers.add(studyRoomUser);
         studyRoom.setStudyRoomUsers(studyRoomUsers);
         StudyRoom savedStudyroom = studyRoomRepository.save(studyRoom);
+        chatService.createRoom(savedStudyroom.getId());
 
         activityRepository.save(Activity.createStudy(user, studyRoom, ActivityType.STUDY_CREATE));
         StudyRoomResponseDto studyRoomResponseDto = StudyRoomResponseDto.toDto(savedStudyroom);


### PR DESCRIPTION
- 실시간 채팅 기능을 위해 stomp 프로토콜을 사용하였고, pub/sub 방식을 사용하였습니다.
- 스터디룸 생성시 자동으로 채팅방 생성
- 웹소켓 연결 /ws/chat
- 채팅 입력시 /pub, 구독자들에게 새로운 채팅 전달시 /sub
- 채팅방의 모든 채팅 가져오기, page로 가져오고 최근순으로 가져옴, 페이지당 100개가 기본
- 채팅방 - 스터디룸은 1대1, 채팅방 - 채팅은 1대n, 유저 - 채팅은 1대n.
- 스터디룸쪽 db 삭제 필요