### PR TITLE
fix: 게시글 수정 기존 이미지 처리 방법 변경

### DIFF
--- a/src/main/java/com/dtalks/dtalks/alarm/service/AlarmServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/alarm/service/AlarmServiceImpl.java
@@ -11,6 +11,7 @@ import com.dtalks.dtalks.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +23,7 @@ public class AlarmServiceImpl implements AlarmService {
     private final AlarmRepository alarmRepository;
 
     @Override
+    @Transactional
     public void updateStatus(Long id) {
         Optional<Alarm> optionalAlarm = alarmRepository.findById(id);
         if (optionalAlarm.isEmpty()) {
@@ -33,6 +35,7 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
+    @Transactional
     public void updateAllStatus() {
         User user = SecurityUtil.getUser();
         List<Alarm> alarmList = alarmRepository.findByReceiverIdAndAlarmStatus(user.getId(), AlarmStatus.WAIT);
@@ -42,6 +45,7 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<AlarmDto> findAllAlarmByUserid() {
         User user = SecurityUtil.getUser();
         List<Alarm> alarmList = alarmRepository.findByReceiverId(user.getId());
@@ -49,6 +53,7 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<AlarmDto> findAllAlarmByUseridAndStatus(AlarmStatus status) {
         User user = SecurityUtil.getUser();
         List<Alarm> alarmList = alarmRepository.findByReceiverIdAndAlarmStatus(user.getId(), status);
@@ -56,12 +61,14 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Long countUnreadAlarm() {
         User user = SecurityUtil.getUser();
         return alarmRepository.countByReceiverIdAndAlarmStatus(user.getId(), AlarmStatus.WAIT);
     }
 
     @Override
+    @Transactional
     public void deleteById(Long id) {
         User user = SecurityUtil.getUser();
         alarmRepository.deleteById(id);

--- a/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.dtalks.dtalks.board.post.controller;
 
 import com.dtalks.dtalks.board.post.dto.FavoriteAndRecommendStatusDto;
+import com.dtalks.dtalks.board.post.dto.PutRequestDto;
 import com.dtalks.dtalks.board.post.service.FavoritePostService;
 import com.dtalks.dtalks.board.post.service.PostService;
 import com.dtalks.dtalks.board.post.dto.PostDto;
@@ -86,9 +87,9 @@ public class PostController {
 
     @Operation(summary = "게시글 수정")
     @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Long> updatePost(@Valid PostRequestDto postDto,
+    public ResponseEntity<Long> updatePost(@Valid PutRequestDto putRequestDto,
                                            @PathVariable Long id) {
-        return ResponseEntity.ok(postService.updatePost(postDto, id));
+        return ResponseEntity.ok(postService.updatePost(putRequestDto, id));
     }
 
 

--- a/src/main/java/com/dtalks/dtalks/board/post/dto/PutRequestDto.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/dto/PutRequestDto.java
@@ -10,13 +10,16 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class PostRequestDto {
+public class PutRequestDto {
     @NotBlank
     private String title;
 
     @NotBlank
     private String content;
 
-    @Schema(description = "게시글 첨부파일(이미지), 없어도 됨.", example = "[첨부파일, 첨부파일]", nullable = true)
+    @Schema(description = "기존 게시글 이미지 url. 없었으면 값 없이 title, content만 주면 됨", nullable = true)
+    private List<String> imgUrls;
+
+    @Schema(description = "새로운 첨부파일(이미지), 없어도 됨.", example = "[첨부파일, 첨부파일]", nullable = true)
     private List<MultipartFile> files;
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.dtalks.dtalks.board.post.service;
 
 import com.dtalks.dtalks.board.post.dto.PostDto;
 import com.dtalks.dtalks.board.post.dto.PostRequestDto;
+import com.dtalks.dtalks.board.post.dto.PutRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -16,7 +17,7 @@ public interface PostService {
     List<PostDto> search5BestPosts();
 
     Long createPost(PostRequestDto postDto);
-    Long updatePost(PostRequestDto postDto, Long id);
+    Long updatePost(PutRequestDto postDto, Long id);
     void deletePost(Long id);
 
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -161,12 +161,15 @@ public class PostServiceImpl implements PostService {
             String documentUrl = document.getUrl();
             // 넘어온 기존 게시글 이미지 url이 없다면 기존 이미지 다 삭제
             boolean isDeleted = true;
-            for (String url : imgUrls) {
-                if (url.equals(documentUrl)) {
-                    isDeleted = false;
-                    break;
+            if (imgUrls != null) {
+                for (String url : imgUrls) {
+                    if (url.equals(documentUrl)) {
+                        isDeleted = false;
+                        break;
+                    }
                 }
             }
+
             if (isDeleted) {
                 imageRepository.delete(dbFile);
                 s3Uploader.deleteFile(document.getPath());


### PR DESCRIPTION
s3 url로만 프론트에서 넘겨줄 수 있어서 남아있는 게시글 이미지는 String으로 넘어올 수 있고 새로운 이미지만 파일 형식으로 올 수 있음.
그거에 맞춰서 새로운 dto 생성.

+알람 transactional 추가