### PR TITLE
feat: 유저 회원 탈퇴 api

### DIFF
--- a/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
+++ b/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
@@ -165,4 +165,11 @@ public class UserController {
         userService.findUserPassword(request, userPasswordFindDto);
         return ResponseEntity.ok().build();
     }
+
+    @Operation(summary = "회원 탈퇴")
+    @DeleteMapping()
+    public ResponseEntity quitUser(UserSimplePasswordDto passwordDto) {
+        userService.quitUser(passwordDto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dtalks/dtalks/user/dto/UserSimplePasswordDto.java
+++ b/src/main/java/com/dtalks/dtalks/user/dto/UserSimplePasswordDto.java
@@ -1,0 +1,11 @@
+package com.dtalks.dtalks.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSimplePasswordDto {
+
+    private String password;
+}

--- a/src/main/java/com/dtalks/dtalks/user/entity/User.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/User.java
@@ -46,7 +46,7 @@ public class User extends BaseTimeEntity implements UserDetails{
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
 
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
 
     @Column(unique = true)

--- a/src/main/java/com/dtalks/dtalks/user/service/UserService.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserService.java
@@ -54,4 +54,6 @@ public interface UserService {
     void findUserid(String email);
 
     void findUserPassword(HttpServletRequest request, UserPasswordFindDto userPasswordFindDto);
+
+    void quitUser(UserSimplePasswordDto passwordDto);
 }


### PR DESCRIPTION
- 회원 탈퇴시 이메일, 아이디 null로 변경, isActive false로 변경, 비밀번호 무작위값으로 변경, nickname (알수없음)으로 변경.
- isActve false이면 로그인 못하도록 수정