### PR TITLE
Fix:닉네임으로 불러오도록 수정, post의 user eager로 변경

### DIFF
--- a/src/main/java/com/dtalks/dtalks/board/comment/controller/CommentController.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/controller/CommentController.java
@@ -39,12 +39,12 @@ public class CommentController {
     }
 
     @Operation(summary = "특정 유저의 댓글 리스트 조회 (페이지 사용, size = 10, sort=\"id\" desc 적용)" , parameters = {
-            @Parameter(name = "userId", description = "조회할 유저의 id (userId, 로그인할때 사용하는 아이디)")
+            @Parameter(name = "nickname", description = "조회할 유저의 닉네임")
     })
-    @GetMapping("/list/user/{userId}")
-    public ResponseEntity<Page<UserCommentDto>> searchUserIdCommentList(@PathVariable String userId,
+    @GetMapping("/list/user/{nickname}")
+    public ResponseEntity<Page<UserCommentDto>> searchUserIdCommentList(@PathVariable String nickname,
                                                                         @PageableDefault(size = 10, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(commentService.searchListByUserId(userId, pageable));
+        return ResponseEntity.ok(commentService.searchListByNickname(nickname, pageable));
     }
 
     @Operation(summary = "특정 게시글에 댓글 저장")

--- a/src/main/java/com/dtalks/dtalks/board/comment/service/CommentService.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/service/CommentService.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface CommentService {
     CommentInfoDto searchById(Long id);
     List<CommentInfoDto> searchListByPostId(Long postId);
-    Page<UserCommentDto> searchListByUserId(String userId, Pageable pageable);
+    Page<UserCommentDto> searchListByNickname(String nickname, Pageable pageable);
 
     void saveComment(Long postId, CommentRequestDto dto);
     void saveReComment(Long postId, Long parentId, CommentRequestDto dto);

--- a/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/comment/service/CommentServiceImpl.java
@@ -88,8 +88,8 @@ public class CommentServiceImpl implements CommentService{
 
     @Override
     @Transactional(readOnly = true)
-    public Page<UserCommentDto> searchListByUserId(String userId, Pageable pageable) {
-        User user = findUser(userId);
+    public Page<UserCommentDto> searchListByNickname(String nickname, Pageable pageable) {
+        User user = findUser(nickname);
         Page<Comment> commentList = commentRepository.findByUserIdAndRemovedFalse(user.getId(), pageable);
         return commentList.map(c -> {
             Post post = c.getPost();
@@ -211,8 +211,8 @@ public class CommentServiceImpl implements CommentService{
     }
 
     @Transactional(readOnly = true)
-    private User findUser(String userid) {
-        return userRepository.findByUserid(userid).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다."));
+    private User findUser(String nickname) {
+        return userRepository.findByNickname(nickname).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다."));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/controller/PostController.java
@@ -45,22 +45,22 @@ public class PostController {
 
 
     @Operation(summary = "특정 유저의 게시글 조회 (페이지 사용, size = 10, sort=\"id\" desc 적용)", parameters = {
-            @Parameter(name = "userId", description = "조회할 유저의 id (userId, 로그인할때 사용하는 아이디)")
+            @Parameter(name = "nickname", description = "조회할 유저의 nickname")
     })
-    @GetMapping("/list/user/{userId}")
-    public ResponseEntity<Page<PostDto>> searchPostsByUser(@PathVariable String userId,
+    @GetMapping("/list/user/{nickname}")
+    public ResponseEntity<Page<PostDto>> searchPostsByUser(@PathVariable String nickname,
                                                            @PageableDefault(size = 10, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(postService.searchPostsByUser(userId, pageable));
+        return ResponseEntity.ok(postService.searchPostsByUser(nickname, pageable));
     }
 
 
     @Operation(summary = "특정 유저의 즐겨찾기 게시글 조회 (페이지 사용, size = 10, sort=\"id\" desc 적용)", parameters = {
-            @Parameter(name = "userId", description = "조회할 유저의 id (userId, 로그인할때 사용하는 아이디)")
+            @Parameter(name = "nickname", description = "조회할 유저의 nickname")
     })
-    @GetMapping("/list/favorite/{userId}")
-    public ResponseEntity<Page<PostDto>> searchFavoritePostsByUser(@PathVariable String userId,
+    @GetMapping("/list/favorite/{nickname}")
+    public ResponseEntity<Page<PostDto>> searchFavoritePostsByUser(@PathVariable String nickname,
                                                            @PageableDefault(size = 10, sort = "id",  direction = Sort.Direction.DESC) Pageable pageable) {
-        return ResponseEntity.ok(favoritePostService.searchFavoritePostsByUser(userId, pageable));
+        return ResponseEntity.ok(favoritePostService.searchFavoritePostsByUser(nickname, pageable));
     }
 
 

--- a/src/main/java/com/dtalks/dtalks/board/post/entity/Post.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/entity/Post.java
@@ -24,7 +24,7 @@ public class Post extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/com/dtalks/dtalks/board/post/service/FavoritePostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/FavoritePostService.java
@@ -9,7 +9,7 @@ public interface FavoritePostService {
     Integer favorite(Long postId);
     Integer unFavorite(Long postId);
 
-    Page<PostDto> searchFavoritePostsByUser(String userId, Pageable pageable);
+    Page<PostDto> searchFavoritePostsByUser(String nickname, Pageable pageable);
 
     boolean checkFavorite(Long postId);
 }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/FavoritePostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/FavoritePostServiceImpl.java
@@ -68,8 +68,8 @@ public class FavoritePostServiceImpl implements FavoritePostService {
     }
 
     @Override
-    public Page<PostDto> searchFavoritePostsByUser(String userId, Pageable pageable) {
-        User user = userRepository.findByUserid(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다."));
+    public Page<PostDto> searchFavoritePostsByUser(String nickname, Pageable pageable) {
+        User user = userRepository.findByNickname(nickname).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다."));
         Page<Post> posts = customPostRepository.searchFavoritePost(user.getId(), pageable);
         return posts.map(PostDto::toDto);
     }

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostService.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface PostService {
     PostDto searchById(Long id);
     Page<PostDto> searchAllPost(Pageable pageable);
-    Page<PostDto> searchPostsByUser(String userId, Pageable pageable);
+    Page<PostDto> searchPostsByUser(String nickname, Pageable pageable);
     Page<PostDto> searchByWord(String keyword, Pageable pageable);
 
     List<PostDto> search5BestPosts();

--- a/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/board/post/service/PostServiceImpl.java
@@ -71,8 +71,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<PostDto> searchPostsByUser(String userId, Pageable pageable) {
-        User user = findUser(userId);
+    public Page<PostDto> searchPostsByUser(String nickname, Pageable pageable) {
+        User user = findUser(nickname);
         Page<Post> posts = postRepository.findByUserId(user.getId(), pageable);
         return posts.map(PostDto::toDto);
     }
@@ -245,8 +245,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Transactional(readOnly = true)
-    private User findUser(String userid) {
-        return userRepository.findByUserid(userid).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다."));
+    private User findUser(String nickname) {
+        return userRepository.findByNickname(nickname).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다."));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
게시글, 댓글 리스트 userId -> nickname으로 가져오게 수정
게시글 불러올때 작성자 닉네임, 이미지 가져오게 수정한 후, user가 무조건 쓰이는데 즐겨찾기 리스트는 querydsl로 작성해 작성자 정보가 lazy loading이면 불러올 수 없었음. 어차피 작성자 정보가 계속 쓰이므로 fetchtype lazy 삭제