### PR TITLE
feat: User status를 활동 타입으로 수정

### DIFF
--- a/src/main/java/com/dtalks/dtalks/admin/report/entity/Report.java
+++ b/src/main/java/com/dtalks/dtalks/admin/report/entity/Report.java
@@ -24,7 +24,8 @@ public abstract class Report extends ReportTimeEntity {
     @OneToOne
     private User reportUser;
 
-    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ReportType reportType;
 
     private String detail;
@@ -32,5 +33,7 @@ public abstract class Report extends ReportTimeEntity {
     @NotNull
     private boolean processed;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ResultType resultType;
 }

--- a/src/main/java/com/dtalks/dtalks/report/controller/ReportController.java
+++ b/src/main/java/com/dtalks/dtalks/report/controller/ReportController.java
@@ -1,8 +1,8 @@
-package com.dtalks.dtalks.admin.report.controller;
+package com.dtalks.dtalks.report.controller;
 
-import com.dtalks.dtalks.admin.report.dto.ReportDetailDto;
-import com.dtalks.dtalks.admin.report.dto.ReportDetailRequestDto;
-import com.dtalks.dtalks.admin.report.service.ReportUserService;
+import com.dtalks.dtalks.report.dto.ReportDetailDto;
+import com.dtalks.dtalks.report.dto.ReportDetailRequestDto;
+import com.dtalks.dtalks.report.service.ReportUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dtalks/dtalks/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/dtalks/dtalks/report/dto/ReportDetailDto.java
@@ -1,8 +1,8 @@
-package com.dtalks.dtalks.admin.report.dto;
+package com.dtalks.dtalks.report.dto;
 
-import com.dtalks.dtalks.admin.report.entity.ReportedUser;
-import com.dtalks.dtalks.admin.report.enums.ReportType;
-import com.dtalks.dtalks.admin.report.enums.ResultType;
+import com.dtalks.dtalks.report.entity.ReportedUser;
+import com.dtalks.dtalks.report.enums.ReportType;
+import com.dtalks.dtalks.report.enums.ResultType;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/dtalks/dtalks/report/dto/ReportDetailRequestDto.java
+++ b/src/main/java/com/dtalks/dtalks/report/dto/ReportDetailRequestDto.java
@@ -1,6 +1,6 @@
-package com.dtalks.dtalks.admin.report.dto;
+package com.dtalks.dtalks.report.dto;
 
-import com.dtalks.dtalks.admin.report.enums.ReportType;
+import com.dtalks.dtalks.report.enums.ReportType;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/dtalks/dtalks/report/entity/Report.java
+++ b/src/main/java/com/dtalks/dtalks/report/entity/Report.java
@@ -1,7 +1,7 @@
-package com.dtalks.dtalks.admin.report.entity;
+package com.dtalks.dtalks.report.entity;
 
-import com.dtalks.dtalks.admin.report.enums.ReportType;
-import com.dtalks.dtalks.admin.report.enums.ResultType;
+import com.dtalks.dtalks.report.enums.ReportType;
+import com.dtalks.dtalks.report.enums.ResultType;
 import com.dtalks.dtalks.user.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/dtalks/dtalks/report/entity/ReportTimeEntity.java
+++ b/src/main/java/com/dtalks/dtalks/report/entity/ReportTimeEntity.java
@@ -1,4 +1,4 @@
-package com.dtalks.dtalks.admin.report.entity;
+package com.dtalks.dtalks.report.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/dtalks/dtalks/report/entity/ReportedUser.java
+++ b/src/main/java/com/dtalks/dtalks/report/entity/ReportedUser.java
@@ -1,4 +1,4 @@
-package com.dtalks.dtalks.admin.report.entity;
+package com.dtalks.dtalks.report.entity;
 
 import com.dtalks.dtalks.user.entity.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/dtalks/dtalks/report/enums/ReportType.java
+++ b/src/main/java/com/dtalks/dtalks/report/enums/ReportType.java
@@ -1,4 +1,4 @@
-package com.dtalks.dtalks.admin.report.enums;
+package com.dtalks.dtalks.report.enums;
 
 public enum ReportType {
     SWEAR_WORD, OTHER;

--- a/src/main/java/com/dtalks/dtalks/report/enums/ResultType.java
+++ b/src/main/java/com/dtalks/dtalks/report/enums/ResultType.java
@@ -1,4 +1,4 @@
-package com.dtalks.dtalks.admin.report.enums;
+package com.dtalks.dtalks.report.enums;
 
 public enum ResultType {
     WAIT, SUSPENSION, BAN, NP

--- a/src/main/java/com/dtalks/dtalks/report/repository/ReportRepository.java
+++ b/src/main/java/com/dtalks/dtalks/report/repository/ReportRepository.java
@@ -1,6 +1,6 @@
-package com.dtalks.dtalks.admin.report.repository;
+package com.dtalks.dtalks.report.repository;
 
-import com.dtalks.dtalks.admin.report.entity.Report;
+import com.dtalks.dtalks.report.entity.Report;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {

--- a/src/main/java/com/dtalks/dtalks/report/repository/ReportedUserRepository.java
+++ b/src/main/java/com/dtalks/dtalks/report/repository/ReportedUserRepository.java
@@ -1,6 +1,6 @@
-package com.dtalks.dtalks.admin.report.repository;
+package com.dtalks.dtalks.report.repository;
 
-import com.dtalks.dtalks.admin.report.entity.ReportedUser;
+import com.dtalks.dtalks.report.entity.ReportedUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/dtalks/dtalks/report/service/ReportUserService.java
+++ b/src/main/java/com/dtalks/dtalks/report/service/ReportUserService.java
@@ -1,7 +1,7 @@
-package com.dtalks.dtalks.admin.report.service;
+package com.dtalks.dtalks.report.service;
 
-import com.dtalks.dtalks.admin.report.dto.ReportDetailDto;
-import com.dtalks.dtalks.admin.report.dto.ReportDetailRequestDto;
+import com.dtalks.dtalks.report.dto.ReportDetailDto;
+import com.dtalks.dtalks.report.dto.ReportDetailRequestDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/dtalks/dtalks/report/service/ReportUserServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/report/service/ReportUserServiceImpl.java
@@ -1,10 +1,10 @@
-package com.dtalks.dtalks.admin.report.service;
+package com.dtalks.dtalks.report.service;
 
-import com.dtalks.dtalks.admin.report.dto.ReportDetailDto;
-import com.dtalks.dtalks.admin.report.dto.ReportDetailRequestDto;
-import com.dtalks.dtalks.admin.report.entity.ReportedUser;
-import com.dtalks.dtalks.admin.report.enums.ResultType;
-import com.dtalks.dtalks.admin.report.repository.ReportedUserRepository;
+import com.dtalks.dtalks.report.dto.ReportDetailDto;
+import com.dtalks.dtalks.report.dto.ReportDetailRequestDto;
+import com.dtalks.dtalks.report.entity.ReportedUser;
+import com.dtalks.dtalks.report.enums.ResultType;
+import com.dtalks.dtalks.report.repository.ReportedUserRepository;
 import com.dtalks.dtalks.exception.ErrorCode;
 import com.dtalks.dtalks.exception.exception.CustomException;
 import com.dtalks.dtalks.user.Util.SecurityUtil;

--- a/src/main/java/com/dtalks/dtalks/user/entity/User.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/User.java
@@ -12,6 +12,7 @@ import com.dtalks.dtalks.qna.question.entity.ScrapQuestion;
 import com.dtalks.dtalks.studyroom.entity.StudyRoomUser;
 import com.dtalks.dtalks.studyroom.enums.Skill;
 import com.dtalks.dtalks.user.dto.UserDto;
+import com.dtalks.dtalks.user.enums.ActiveStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
@@ -69,7 +70,9 @@ public class User extends BaseTimeEntity implements UserDetails{
     @Column(nullable = false)
     private Boolean isActive;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ActiveStatus status;
 
     @Column(nullable = false)
     private Boolean isPrivate;

--- a/src/main/java/com/dtalks/dtalks/user/enums/ActiveStatus.java
+++ b/src/main/java/com/dtalks/dtalks/user/enums/ActiveStatus.java
@@ -1,0 +1,5 @@
+package com.dtalks.dtalks.user.enums;
+
+public enum ActiveStatus {
+    ACTIVE, SUSPENSION, BAN, QUIT
+}

--- a/src/main/java/com/dtalks/dtalks/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserServiceImpl.java
@@ -14,6 +14,7 @@ import com.dtalks.dtalks.user.Util.SecurityUtil;
 import com.dtalks.dtalks.user.dto.*;
 import com.dtalks.dtalks.user.entity.AccessTokenPassword;
 import com.dtalks.dtalks.user.entity.User;
+import com.dtalks.dtalks.user.enums.ActiveStatus;
 import com.dtalks.dtalks.user.repository.AccessTokenPasswordRepository;
 import com.dtalks.dtalks.user.repository.UserRepository;
 import jakarta.mail.internet.MimeMessage;
@@ -61,6 +62,7 @@ public class UserServiceImpl implements UserService {
         user.setSkills(oAuthSignUpDto.getSkills());
         user.setDescription(oAuthSignUpDto.getDescription());
         user.setIsActive(true);
+        user.setStatus(ActiveStatus.ACTIVE);
         user.setIsPrivate(false);
 
         User savedUser = userRepository.save(user);
@@ -88,6 +90,7 @@ public class UserServiceImpl implements UserService {
                 .description(signUpDto.getDescription())
                 .roles(Collections.singletonList("USER"))
                 .isActive(true)
+                .status(ActiveStatus.ACTIVE)
                 .isPrivate(false)
                 .build();
 
@@ -380,6 +383,7 @@ public class UserServiceImpl implements UserService {
         user.setUserid(null);
         user.setNickname(null);
         user.setIsActive(false);
+        user.setStatus(ActiveStatus.QUIT);
         user.setPassword(passwordEncoder.encode(UUID.randomUUID().toString()));
 
         List<Notification> notificationList = notificationRepository.findByReceiverId(user.getId());


### PR DESCRIPTION
사용하지 않던 status를 ActiveStatus enum 으로 수정. 회원가입 시 활동을 뜻하는 ACTIVE로 되고 탈퇴 시에는 QUIT, 관리자에 의해 정지될 경우 SUSPENSION, 계정이 아예 잠길 경우(금지)에는 BAN으로 설정