### PR TITLE
fix: 유저 스킬, 역할 fetch lazy 원하는 시점에 쿼리 하도록 변경

### DIFF
--- a/src/main/java/com/dtalks/dtalks/user/dto/UserResponseDto.java
+++ b/src/main/java/com/dtalks/dtalks/user/dto/UserResponseDto.java
@@ -4,6 +4,7 @@ import com.dtalks.dtalks.studyroom.enums.Skill;
 import com.dtalks.dtalks.user.entity.User;
 import lombok.Builder;
 import lombok.Data;
+import org.hibernate.Hibernate;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class UserResponseDto {
     private String registrationId;
 
     public static UserResponseDto toDto(User user) {
+        Hibernate.initialize(user.getSkills());
         return UserResponseDto.builder()
                 .userid(user.getUserid())
                 .nickname(user.getNickname())

--- a/src/main/java/com/dtalks/dtalks/user/entity/User.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/User.java
@@ -56,11 +56,11 @@ public class User extends BaseTimeEntity implements UserDetails{
 
     private String registrationId;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @Builder.Default // 빌더 패턴을 통해 인스턴스를 만들 때 특정 필드값으로 초기화
     private List<String> roles = new ArrayList<>();
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @Builder.Default
     private List<Skill> skills = new ArrayList<>();
 

--- a/src/main/java/com/dtalks/dtalks/user/entity/User.java
+++ b/src/main/java/com/dtalks/dtalks/user/entity/User.java
@@ -56,11 +56,11 @@ public class User extends BaseTimeEntity implements UserDetails{
 
     private String registrationId;
 
-    @ElementCollection(fetch = FetchType.LAZY)
+    @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default // 빌더 패턴을 통해 인스턴스를 만들 때 특정 필드값으로 초기화
     private List<String> roles = new ArrayList<>();
 
-    @ElementCollection(fetch = FetchType.LAZY)
+    @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
     private List<Skill> skills = new ArrayList<>();
 


### PR DESCRIPTION
lazy로 설정시 could not initialize proxy - no Session 에러가 발생합니다.
서비스 단에서 데이터를 필요로 하지 않아 컨트롤러에서 리턴 할 때 fetch lazy가 실행되어 영속 컨텍스트가 존재하지 않아 에러가 발생하는 것으로 추측됩니다. 로그 출력등의 코드를 넣어 강제로 사용하도록 하게 할 경우 쿼리가 수행되지만, 매번 이렇게 하면 쓸모없는 로그가 너무 많이 찍힌다고 생각했고 마땅히 더 좋은 방법이 생각나지 않아 우선 eager로 바꾸어 주었습니다.
