### PR TITLE
fix: 스터디룸 삭제시 채팅방, 채팅 삭제

### DIFF
--- a/src/main/java/com/dtalks/dtalks/studyroom/entity/ChatRoom.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/entity/ChatRoom.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Setter
 @Getter
@@ -16,4 +19,7 @@ public class ChatRoom extends BaseTimeEntity {
 
     @OneToOne(orphanRemoval = true, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private StudyRoom studyRoom;
+
+    @OneToMany(mappedBy = "chatRoom", orphanRemoval = true)
+    private List<ChatMessage> chatMessages = new ArrayList<>();
 }

--- a/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/studyroom/service/StudyRoomServiceImpl.java
@@ -13,6 +13,7 @@ import com.dtalks.dtalks.studyroom.dto.StudyRoomResponseDto;
 import com.dtalks.dtalks.studyroom.entity.StudyRoom;
 import com.dtalks.dtalks.studyroom.entity.StudyRoomUser;
 import com.dtalks.dtalks.studyroom.enums.StudyRoomLevel;
+import com.dtalks.dtalks.studyroom.repository.ChatRoomRepository;
 import com.dtalks.dtalks.studyroom.repository.StudyRoomRepository;
 import com.dtalks.dtalks.studyroom.repository.StudyRoomUserRepository;
 import com.dtalks.dtalks.user.Util.SecurityUtil;
@@ -46,7 +47,7 @@ public class StudyRoomServiceImpl implements StudyRoomService{
     private final UserRepository userRepository;
     private final NotificationRepository notificationRepository;
     private final ChatService chatService;
-
+    private final ChatRoomRepository chatRoomRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final MessageSource messageSource;
 
@@ -134,7 +135,7 @@ public class StudyRoomServiceImpl implements StudyRoomService{
         for(StudyRoomUser studyRoomUser: studyRoomUsers) {
             if(studyRoomUser.getStudyRoomLevel().equals(StudyRoomLevel.LEADER)) {
                 if(studyRoomUser.getUser().getUserid().equals(SecurityUtil.getUser().getUserid())) {
-                    studyRoomRepository.delete(studyRoom);
+                    chatRoomRepository.delete(chatRoomRepository.findById(studyRoom.getId()).get());
                     return;
                 }
             }


### PR DESCRIPTION
스터디룸 삭제시 스터디룸과 채팅방이 1대1 단방향으로 연결되어 있어 채팅방을 삭제해야 스터디룸이 같이 삭제되므로 그렇게 변경하였습니다.
채팅방 삭제시 채팅이 삭제되어야 하는데 다대일 단방향으로 연결되어 있어 이를 양방향으로 바꾼뒤 고아가 될경우 삭제하도록 처리하였습니다.