### PR TITLE
fix: 계정 정지 사용자 인증 변경, filter 리스트 변경, 사용자 비공개 조회 닉네임으로 수정

### DIFF
--- a/src/main/java/com/dtalks/dtalks/user/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dtalks/dtalks/user/config/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] SHOULD_NOT_FILTER_URI_ALL_LIST = new String[]{
             "/sign-in/**", "/sign-up", "exception", "/users/check/**", "/email/**"
-            ,"/token/refresh", "/ws/chat/**", "/sub/**", "/pub/**", "/notifications/**", "/admin/sign-in",
+            ,"/token/refresh", "/ws/chat/**", "/sub/**", "/pub/**", "/admin/sign-in",
             "**exception**", "/users/recent/activity/**", "/users/private/**"
     };
 

--- a/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
+++ b/src/main/java/com/dtalks/dtalks/user/controller/UserController.java
@@ -113,13 +113,13 @@ public class UserController {
     }
 
     @Operation(summary = "특정 유저의 비공개 여부 조회", parameters = {
-            @Parameter(name = "id", description = "조회할 유저의 로그인 아이디"),
+            @Parameter(name = "nickname", description = "조회할 유저의 닉네임"),
     }, responses = {
             @ApiResponse(responseCode = "400", description = "해당 사용자가 db에 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponseDto.class)))
     })
-    @GetMapping(value = "/private/{id}")
-    public ResponseEntity<Boolean> getPrivateStatus(@PathVariable String id) {
-        return ResponseEntity.ok(userService.getPrivateStatus(id));
+    @GetMapping(value = "/private/{nickname}")
+    public ResponseEntity<Boolean> getPrivateStatus(@PathVariable String nickname) {
+        return ResponseEntity.ok(userService.getPrivateStatus(nickname));
     }
 
     @Operation(summary = "특정 유저의 비공개 여부 설정", parameters = {

--- a/src/main/java/com/dtalks/dtalks/user/service/TokenServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/TokenServiceImpl.java
@@ -3,7 +3,6 @@ package com.dtalks.dtalks.user.service;
 import com.dtalks.dtalks.exception.ErrorCode;
 import com.dtalks.dtalks.exception.exception.CustomException;
 import com.dtalks.dtalks.user.entity.User;
-import com.dtalks.dtalks.user.enums.ActiveStatus;
 import com.dtalks.dtalks.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -22,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
-import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Date;
 
@@ -96,9 +94,6 @@ public class TokenServiceImpl implements TokenService {
     public Authentication getAuthentication(String token) {
         User user = userRepository.findById(this.getIdByToken(token)).orElseThrow(
                 () -> new CustomException(ErrorCode.VALIDATION_ERROR, "존재하지 않는 사용자입니다."));
-        if (user.getStatus() != ActiveStatus.ACTIVE) {
-            throw new CustomException(ErrorCode.PERMISSION_NOT_GRANTED_ERROR, "현재 정지 상태로 활동이 불가능합니다.");
-        }
 
         return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
     }

--- a/src/main/java/com/dtalks/dtalks/user/service/UserService.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserService.java
@@ -49,7 +49,7 @@ public interface UserService {
 
     void updatePrivate(boolean status);
 
-    Boolean getPrivateStatus(String id);
+    Boolean getPrivateStatus(String nickname);
 
     void findUserid(String email);
 

--- a/src/main/java/com/dtalks/dtalks/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dtalks/dtalks/user/service/UserServiceImpl.java
@@ -339,8 +339,8 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional(readOnly = true)
-    public Boolean getPrivateStatus(String id) {
-        User user = findUser(id);
+    public Boolean getPrivateStatus(String nickname) {
+        User user = userRepository.findByNickname(nickname).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_ERROR, "유저를 찾을 수 없습니다."));
         return user.getIsPrivate();
     }
 


### PR DESCRIPTION
- SecurityUtil.getUser()와 같은 사용으로 컨텍스트 홀더에서 사용자 인증 정보를 가져올 때 계정 정지 된 사용자면 정보를 가져오지 못 하는 에러 발생.
1. SecurityUtil을 사용하는 GET 메소드 파악, 필터 리스트 수정
2. doFilterInternal에서 컨텍스트 홀더에 사용자 인증 정보 저장 후 GET요청이 아닐 때 에러 발생하도록 수정

- 사용자 비공개 조회를 사용자 로그인 아이디에서 닉네임으로 수정